### PR TITLE
feat: 회원가입 오류 수정 및 게시글 작성시 Token 함께 전송

### DIFF
--- a/src/api/post.ts
+++ b/src/api/post.ts
@@ -1,6 +1,7 @@
 import { ApiEmotion } from "@/types/Emotion";
 import defaultInstance from "./instance/defaultInstance";
 import formInstance from "./instance/formInstance";
+import { TOKEN_KEY } from "@/store/useTokenStore";
 
 export const getPostList = async ({
   page,
@@ -36,7 +37,12 @@ export const postPost = async (post: IPost) => {
   formData.append("content", post.content);
   formData.append("emotion", post.emotion);
 
-  const response = await formInstance.post("/posts", formData);
+  // localStorage에서 accessToken 가져오기
+  const accessToken = localStorage.getItem(TOKEN_KEY);
+
+  const response = await formInstance.post("/posts", formData, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
   return response.data;
 };
 

--- a/src/api/post.ts
+++ b/src/api/post.ts
@@ -1,6 +1,5 @@
 import { ApiEmotion } from "@/types/Emotion";
 import defaultInstance from "./instance/defaultInstance";
-import { ApiAnimalType } from "@/types/animal";
 import formInstance from "./instance/formInstance";
 
 export const getPostList = async ({
@@ -22,7 +21,6 @@ export const getPostList = async ({
 interface IPost {
   images: File[];
   emotion: ApiEmotion;
-  post_type: ApiAnimalType;
   content: string;
 }
 
@@ -37,13 +35,12 @@ export const postPost = async (post: IPost) => {
   // 다른 데이터들 추가
   formData.append("content", post.content);
   formData.append("emotion", post.emotion);
-  formData.append("post_type", post.post_type);
 
   const response = await formInstance.post("/posts", formData);
   return response.data;
 };
 
 export const getPostDetail = async (postId: number) => {
-  const response = await defaultInstance.get(`/posts/${postId}`);
+  const response = await formInstance.get(`/posts/${postId}`);
   return response.data;
 };

--- a/src/api/queries/loginQueries.ts
+++ b/src/api/queries/loginQueries.ts
@@ -35,11 +35,18 @@ export const loginQueries = {
     },
   }),
 
-  login: ({ setToken }: { setToken: (token: string) => void }) => ({
+  login: ({
+    setToken,
+    navigate,
+  }: {
+    setToken: (token: string) => void;
+    navigate: NavigateFunction;
+  }) => ({
     mutationKey: [...loginQueries.all(), "login"],
     mutationFn: (kakaoId: number) => postLogin(kakaoId),
     onSuccess: (data: ILoginResponse) => {
       setToken(data.accessToken);
+      navigate("/");
     },
     onError: (error: Error) => {
       console.error("Login failed:", error);

--- a/src/api/queries/loginQueries.ts
+++ b/src/api/queries/loginQueries.ts
@@ -1,6 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 import { IKakaoAuthResponse, ILoginCode, ILoginResponse } from "@/api/types";
 import { getKakaoId, getKakaoUrl, postLogin } from "@/api/login";
+import { NavigateFunction } from "react-router-dom";
 
 export const loginQueries = {
   all: () => ["login"] as const,
@@ -11,16 +12,25 @@ export const loginQueries = {
       queryFn: () => getKakaoUrl(),
     }),
 
-  kakaoId: ({ setKakaoId }: { setKakaoId: (kakaoId: number) => void }) => ({
+  kakaoId: ({
+    setKakaoId,
+    login,
+    navigate,
+  }: {
+    setKakaoId: (kakaoId: number) => void;
+    login: (id: number) => void;
+    navigate: NavigateFunction;
+  }) => ({
     mutationKey: [...loginQueries.all(), "kakaoId"],
     mutationFn: ({ code }: ILoginCode) => getKakaoId(code),
     onSuccess: (data: IKakaoAuthResponse) => {
       setKakaoId(data.kakaoId);
-    },
-    onError: (error: { response: { data: { kakaoId: number } } }) => {
-      // TEMP : 임시 코드임. 401 뜨는 에러 해결되면 제거해야함!
-      if (error.response.data.kakaoId) {
-        setKakaoId(error.response.data.kakaoId);
+
+      if (data.isMember) {
+        login(data.kakaoId);
+        navigate("/");
+      } else {
+        navigate("/signup");
       }
     },
   }),

--- a/src/api/queries/postQueries.ts
+++ b/src/api/queries/postQueries.ts
@@ -2,7 +2,6 @@ import { IPostSummaryDataPagination } from "@/api/types";
 import { getPostDetail, getPostList, postPost } from "../post";
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { IPostDetailData } from "@/api/types";
-import { ApiAnimalType } from "@/types/animal";
 import { ICreatePost } from "../types";
 
 export const postQueries = {
@@ -31,8 +30,6 @@ export const postQueries = {
         images,
         content,
         emotion,
-        // TODO : 로그인 정보에 있는 animal type 불러오도록
-        post_type: ApiAnimalType.CAT,
       }),
     onError: () => {
       alert("게시글 작성에 실패했다옹. 잠시 후 다시 시도해보라냥");

--- a/src/api/queries/signupQueries.ts
+++ b/src/api/queries/signupQueries.ts
@@ -1,6 +1,6 @@
 import { UseMutationOptions } from "@tanstack/react-query";
 import { getDuplicateNickname, postUsers } from "@/api/signup";
-import { ISignupResponse, IUserRequest } from "@/api/types";
+import { IUserRequest } from "@/api/types";
 
 export const signupQueries = {
   all: () => ["signup"] as const,
@@ -12,15 +12,18 @@ export const signupQueries = {
 
   signup: ({
     setKakaoId,
+    login,
   }: {
     setKakaoId: (kakaoId: number) => void;
-  }): UseMutationOptions<ISignupResponse, Error, IUserRequest> => ({
+    login: (id: number) => void;
+  }) => ({
     mutationKey: [...signupQueries.all(), "signup"],
     mutationFn: (data: IUserRequest) => postUsers(data),
-    onSuccess: (data) => {
-      setKakaoId(data.data.kakaoId);
+    onSuccess: (data: number) => {
+      setKakaoId(data);
+      login(data);
     },
-    onError: (error) => {
+    onError: (error: Error) => {
       console.error("Signup failed:", error);
       alert("회원가입에 실패했다옹... 다시 시도해달라옹");
     },

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -10,13 +10,6 @@ export interface IKakaoAuthResponse {
   isMember: boolean;
 }
 
-export interface ISignupResponse {
-  message: string;
-  data: {
-    kakaoId: number;
-  };
-}
-
 export interface ILoginResponse {
   accessToken: string;
 }

--- a/src/app/login/LoginPage.tsx
+++ b/src/app/login/LoginPage.tsx
@@ -1,6 +1,19 @@
 import LoginButton from "@/components/pages/LoginButton";
+import { TOKEN_KEY } from "@/store/useTokenStore";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 
 export default function LoginPage() {
+  const navigate = useNavigate();
+  const token = localStorage.getItem(TOKEN_KEY);
+
+  useEffect(() => {
+    if (token) {
+      alert("이미 로그인 되어 있다옹");
+      navigate(-1);
+    }
+  }, [navigate, token]);
+
   return (
     <div className="flex flex-col items-center justify-center min-h-[60vh] gap-10">
       <h2 className="text-4xl">£ 어서오라옹 ¢</h2>

--- a/src/app/redirect/RedirectPage.tsx
+++ b/src/app/redirect/RedirectPage.tsx
@@ -7,38 +7,25 @@ import { loginQueries } from "@/api/queries/loginQueries";
 
 export default function RedirectPage() {
   const navigate = useNavigate();
-  const setKakaoId = useKakaoIdStore((state) => state.setKakaoId);
+  const { setKakaoId } = useKakaoIdStore();
   const { token, setToken } = useTokenStore();
 
   const [searchParams] = useSearchParams();
   const code = searchParams.get("code");
 
-  const {
-    mutate: getKakao,
-    data: kakaoData,
-    isSuccess: isKakaoSuccess,
-  } = useMutation({
-    ...loginQueries.kakaoId({ setKakaoId }),
-  });
-
   const { mutate: login } = useMutation({
     ...loginQueries.login({ setToken }),
+  });
+
+  const { mutate: getKakao } = useMutation({
+    ...loginQueries.kakaoId({ setKakaoId, login, navigate }),
   });
 
   useEffect(() => {
     if (code) {
       getKakao({ code });
     }
-  }, [code, getKakao, kakaoData]);
-
-  useEffect(() => {
-    if (isKakaoSuccess && kakaoData?.isMember) {
-      login(kakaoData.kakaoId);
-      navigate("/");
-    } else if (isKakaoSuccess && !kakaoData?.isMember) {
-      navigate("/signup");
-    }
-  }, [isKakaoSuccess, kakaoData, login, navigate]);
+  }, [code, getKakao]);
 
   useEffect(() => {
     if (token) {

--- a/src/app/redirect/RedirectPage.tsx
+++ b/src/app/redirect/RedirectPage.tsx
@@ -14,7 +14,7 @@ export default function RedirectPage() {
   const code = searchParams.get("code");
 
   const { mutate: login } = useMutation({
-    ...loginQueries.login({ setToken }),
+    ...loginQueries.login({ setToken, navigate }),
   });
 
   const { mutate: getKakao } = useMutation({

--- a/src/components/pages/MemberForm/SignupForm.tsx
+++ b/src/components/pages/MemberForm/SignupForm.tsx
@@ -16,14 +16,14 @@ export default function SignupForm() {
   const { kakaoId, setKakaoId } = useKakaoIdStore();
   const { token, setToken } = useTokenStore();
   const { mutate: login, isPending: isLoginPending } = useMutation({
-    ...loginQueries.login({ setToken }),
+    ...loginQueries.login({ setToken, navigate }),
   });
   const {
     mutate: signup,
     isPending: isSignupPending,
     isSuccess: isSignupSuccess,
   } = useMutation({
-    ...signupQueries.signup({ setKakaoId }),
+    ...signupQueries.signup({ setKakaoId, login }),
   });
 
   const [selectedImage, setSelectedImage] = useState<File | null>(null);

--- a/src/components/pages/PostForm/ImageInput.tsx
+++ b/src/components/pages/PostForm/ImageInput.tsx
@@ -16,7 +16,7 @@ function ImagePreview({ image, onDelete }: ImagePreviewProps) {
   const { previewUrl } = useImagePreview({ initialImage: image.file });
 
   return (
-    <div className="relative w-[100px] h-[100px] border border-foreground/30 rounded-2xl">
+    <div className="relative w-[100px] h-[100px] outline outline-foreground/30 rounded-2xl">
       <img
         src={previewUrl || image.preview}
         alt="Preview"
@@ -58,7 +58,7 @@ export default function ImageInput({
     <div className="flex flex-col gap-0 items-center px-2 py-2">
       <div className="flex gap-3">
         {selectedImages.length < MAX_IMAGES && (
-          <label className="flex items-center justify-center w-[100px] h-[100px] bg-orange-100 border border-foreground/30 rounded-2xl cursor-pointer">
+          <label className="flex items-center justify-center w-[100px] h-[100px] bg-orange-100 outline outline-foreground/30 rounded-2xl cursor-pointer">
             <div className="flex flex-col items-center gap-2">
               <span className="text-2xl">+</span>
               <span className="text-sm">사진을 추가해라냥</span>


### PR DESCRIPTION
## 🚀 작업 내용
- 회원가입 오류 수정 
- 로그인 페이지에 로그인 되어 있는 경우에는 못 들어가도록
- 게시글 작성시 사용자 정보(토큰) 함께 전송되도록 함
- 게시글 작성 페이지의 이미지 입력 컴포넌트 코너 안 맞는 오류 수정

## ✨ 작업 상세 설명
- 회원 가입 오류는 data 불일치 문제였음 => API 명세서 수정 및, data type 수정

### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 🔨 추후 수정해야 하는 부분 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
