### PR TITLE
fix: login 요청 두번 되는 오류 & 닉네임 유효성 검사 확실하게

### DIFF
--- a/src/components/pages/MemberForm/NicknameInput.tsx
+++ b/src/components/pages/MemberForm/NicknameInput.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { useEffect, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { signupQueries } from "@/api/queries/signupQueries";
+import { validateNickname } from "./validation/validateNickname";
 
 export interface INicknameInput {
   isRequired?: boolean;
@@ -41,13 +42,9 @@ export default function NicknameInput({
     setSuccessMessage(null);
     onDuplicateCheck?.(true); // Reset duplicate check status when nickname changes
 
-    const emojiRegex = /[\p{Emoji}]/u;
-    if (emojiRegex.test(value)) {
-      setError("이모지 없이 적어달라옹");
-    } else if (value.length < 3) {
-      setError("닉네임은 3자 이상이어야 한다옹");
-    } else if (value.length > 15) {
-      setError("닉네임은 15자 이하여야 한다옹");
+    const { isValid, message } = validateNickname(value);
+    if (!isValid) {
+      setError(message);
     } else {
       setError(null);
     }
@@ -96,7 +93,7 @@ export default function NicknameInput({
           variant="primaryOutline"
           className="h-full px-5 rounded-xl text-foreground text-lg font-bold"
           onClick={handleCheckNickname}
-          disabled={isPending}
+          disabled={isPending || !validateNickname(nicknameValue).isValid}
         >
           {isPending ? "확인 중..." : "중복 확인"}
         </Button>

--- a/src/components/pages/MemberForm/SignupForm.tsx
+++ b/src/components/pages/MemberForm/SignupForm.tsx
@@ -18,11 +18,7 @@ export default function SignupForm() {
   const { mutate: login, isPending: isLoginPending } = useMutation({
     ...loginQueries.login({ setToken, navigate }),
   });
-  const {
-    mutate: signup,
-    isPending: isSignupPending,
-    isSuccess: isSignupSuccess,
-  } = useMutation({
+  const { mutate: signup, isPending: isSignupPending } = useMutation({
     ...signupQueries.signup({ setKakaoId, login }),
   });
 
@@ -57,12 +53,6 @@ export default function SignupForm() {
       navigate("/");
     }
   }, [token, navigate]);
-
-  useEffect(() => {
-    if (isSignupSuccess && kakaoId) {
-      login(kakaoId);
-    }
-  }, [isSignupSuccess, kakaoId, login]);
 
   return (
     <div className="flex flex-col gap-4 items-center pt-8">

--- a/src/components/pages/MemberForm/validation/validateNickname.ts
+++ b/src/components/pages/MemberForm/validation/validateNickname.ts
@@ -1,0 +1,13 @@
+import { ValidationReturnType } from "@/types/ValidationReturnType";
+
+export const validateNickname = (nickname: string): ValidationReturnType => {
+  const emojiRegex = /[\p{Emoji}]/u;
+  if (emojiRegex.test(nickname)) {
+    return { isValid: false, message: "이모지 없이 적어달라옹" };
+  } else if (nickname.length < 3) {
+    return { isValid: false, message: "닉네임은 3자 이상이어야 한다옹" };
+  } else if (nickname.length > 15) {
+    return { isValid: false, message: "닉네임은 15자 이하여야 한다옹" };
+  }
+  return { isValid: true, message: "" };
+};


### PR DESCRIPTION
## 🚀 작업 내용

- login 요청이 두번씩 날아가는 오류 발견
- 닉네임 유효성 검사 안해도 중복 확인만 하면 회원가입 되는 오류 발견

## ✨ 작업 상세 설명

- login 요청 보내는 불필요한 추가 로직 제거
- 닉네임 유효한 경우에만 중복 확인 버튼 누르도록 수정

### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 🔨 추후 수정해야 하는 부분 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
