### PR TITLE
feat: refresh token 사용

### DIFF
--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -20,3 +20,8 @@ export const postLogin = async (kakaoId: number) => {
   });
   return response.data;
 };
+
+export const postRefresh = async () => {
+  const response = await defaultInstance.post("/auth/refresh");
+  return response.data;
+};

--- a/src/api/queries/loginQueries.ts
+++ b/src/api/queries/loginQueries.ts
@@ -1,6 +1,6 @@
 import { queryOptions } from "@tanstack/react-query";
 import { IKakaoAuthResponse, ILoginCode, ILoginResponse } from "@/api/types";
-import { getKakaoId, getKakaoUrl, postLogin } from "@/api/login";
+import { getKakaoId, getKakaoUrl, postLogin, postRefresh } from "@/api/login";
 import { NavigateFunction } from "react-router-dom";
 
 export const loginQueries = {
@@ -51,6 +51,24 @@ export const loginQueries = {
     onError: (error: Error) => {
       console.error("Login failed:", error);
       alert("로그인에 실패했다옹... 다시 시도해달라옹");
+    },
+  }),
+
+  refresh: ({
+    setToken,
+    navigate,
+    onRefreshSuccess,
+  }: {
+    setToken: (token: string) => void;
+    navigate: NavigateFunction;
+    onRefreshSuccess?: () => void;
+  }) => ({
+    mutationKey: [...loginQueries.all(), "refresh"],
+    mutationFn: () => postRefresh(),
+    onSuccess: (data: ILoginResponse) => {
+      setToken(data.accessToken);
+      onRefreshSuccess?.();
+      navigate("/");
     },
   }),
 };

--- a/src/api/queries/loginQueries.ts
+++ b/src/api/queries/loginQueries.ts
@@ -56,11 +56,9 @@ export const loginQueries = {
 
   refresh: ({
     setToken,
-    navigate,
     onRefreshSuccess,
   }: {
     setToken: (token: string) => void;
-    navigate: NavigateFunction;
     onRefreshSuccess?: () => void;
   }) => ({
     mutationKey: [...loginQueries.all(), "refresh"],
@@ -68,7 +66,6 @@ export const loginQueries = {
     onSuccess: (data: ILoginResponse) => {
       setToken(data.accessToken);
       onRefreshSuccess?.();
-      navigate("/");
     },
   }),
 };

--- a/src/api/queries/postQueries.ts
+++ b/src/api/queries/postQueries.ts
@@ -1,8 +1,9 @@
-import { IPostSummaryDataPagination } from "@/api/types";
+import { IError, IPostSummaryDataPagination } from "@/api/types";
 import { getPostDetail, getPostList, postPost } from "../post";
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { IPostDetailData } from "@/api/types";
 import { ICreatePost } from "../types";
+import { AxiosError } from "axios";
 
 export const postQueries = {
   all: () => ["post"] as const,
@@ -32,8 +33,8 @@ export const postQueries = {
         content,
         emotion,
       }),
-    onError: (error) => {
-      if (error.code === "401") {
+    onError: (error: AxiosError<IError>) => {
+      if (error.response?.status === 401) {
         refresh();
         return;
       } else {

--- a/src/api/queries/postQueries.ts
+++ b/src/api/queries/postQueries.ts
@@ -24,7 +24,7 @@ export const postQueries = {
       queryFn: () => getPostDetail(postId),
     }),
 
-  create: () => ({
+  create: ({ refresh }: { refresh: () => void }) => ({
     mutationKey: [...postQueries.all(), "create"],
     mutationFn: ({ images, content, emotion }: ICreatePost) =>
       postPost({
@@ -32,8 +32,13 @@ export const postQueries = {
         content,
         emotion,
       }),
-    onError: () => {
-      alert("게시글 작성에 실패했다옹. 잠시 후 다시 시도해보라냥");
+    onError: (error) => {
+      if (error.code === "401") {
+        refresh();
+        return;
+      } else {
+        alert("게시글 작성에 실패했다옹. 잠시 후 다시 시도해보라냥");
+      }
     },
   }),
 };

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,6 +1,11 @@
 import { ApiAnimalType } from "@/types/animal";
 import { ApiEmotion } from "@/types/Emotion";
 
+export interface IError {
+  statusCode: number;
+  data: unknown | null;
+}
+
 export interface ILoginCode {
   code: string;
 }

--- a/src/components/pages/PostForm/CreatePostForm.tsx
+++ b/src/components/pages/PostForm/CreatePostForm.tsx
@@ -17,7 +17,6 @@ export default function CreatePostForm() {
   const { mutate: refresh } = useMutation({
     ...loginQueries.refresh({
       setToken,
-      navigate,
       onRefreshSuccess: () => {
         createPost({
           images: selectedImages.map((img) => img.file),

--- a/src/components/pages/PostForm/CreatePostForm.tsx
+++ b/src/components/pages/PostForm/CreatePostForm.tsx
@@ -8,15 +8,31 @@ import { useImageUpload } from "@/hooks/common/useImageUpload";
 import { ApiEmotion } from "@/types/Emotion";
 import { postQueries } from "@/api/queries/postQueries";
 import { useMutation } from "@tanstack/react-query";
+import { loginQueries } from "@/api/queries/loginQueries";
+import useTokenStore from "@/store/useTokenStore";
 
 export default function CreatePostForm() {
   const navigate = useNavigate();
+  const { setToken } = useTokenStore();
+  const { mutate: refresh } = useMutation({
+    ...loginQueries.refresh({
+      setToken,
+      navigate,
+      onRefreshSuccess: () => {
+        createPost({
+          images: selectedImages.map((img) => img.file),
+          content,
+          emotion: selectedEmotion,
+        });
+      },
+    }),
+  });
   const {
     mutate: createPost,
     isPending,
     isSuccess,
     isError,
-  } = useMutation({ ...postQueries.create() });
+  } = useMutation({ ...postQueries.create({ refresh }) });
 
   const { selectedImages, addImages, removeImage, error } = useImageUpload();
   const [content, setContent] = useState("");


### PR DESCRIPTION
## 🚀 작업 내용
- access token 만료시 refresh token 사용해서 새로운 `accessToken` 발급 받도록 구현
- 특히 게시글 작성시, access token 이 만료되면 새로운 token 발급 받고 게시글 업로드 되도록 구현

## ✨ 작업 상세 설명

### 🔥 문제 상황 (선택)
- 트러블 슈팅 로그에 기록 예정

### 💦 해결 방법 (선택)

## 🔨 추후 수정해야 하는 부분 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
