### PR TITLE
86/fix/token으로 게시글 조회 성능 최적화

### DIFF
--- a/src/api/instance/authInstance.ts
+++ b/src/api/instance/authInstance.ts
@@ -1,5 +1,6 @@
-import { TOKEN_KEY } from "@/store/useTokenStore";
+import useTokenStore, { TOKEN_KEY } from "@/store/useTokenStore";
 import axios from "axios";
+import { postRefresh } from "../login";
 
 const baseURL = `${import.meta.env.VITE_API_URL}`;
 
@@ -19,6 +20,30 @@ authInstance.interceptors.request.use(
     return config;
   },
   (error) => {
+    return Promise.reject(error);
+  },
+);
+
+authInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      try {
+        const response: { accessToken: string } = await postRefresh();
+        const newToken = response.accessToken;
+        useTokenStore.getState().setToken(newToken);
+
+        originalRequest.headers.Authorization = `Bearer ${newToken}`;
+        return authInstance(originalRequest);
+      } catch (refreshError) {
+        return Promise.reject(refreshError);
+      }
+    }
+
     return Promise.reject(error);
   },
 );

--- a/src/api/instance/authInstance.ts
+++ b/src/api/instance/authInstance.ts
@@ -1,4 +1,4 @@
-import useTokenStore, { TOKEN_KEY } from "@/store/useTokenStore";
+import useTokenStore from "@/store/useTokenStore";
 import axios from "axios";
 import { postRefresh } from "../login";
 
@@ -13,7 +13,7 @@ const authInstance = axios.create({
 
 authInstance.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem(TOKEN_KEY);
+    const token = useTokenStore.getState().token;
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }

--- a/src/api/instance/authInstance.ts
+++ b/src/api/instance/authInstance.ts
@@ -40,6 +40,8 @@ authInstance.interceptors.response.use(
         originalRequest.headers.Authorization = `Bearer ${newToken}`;
         return authInstance(originalRequest);
       } catch (refreshError) {
+        alert("토큰 갱신에 실패했다옹... 로그아웃 하고 다시 로그인 해보라냥");
+        window.location.href = "/login";
         return Promise.reject(refreshError);
       }
     }

--- a/src/api/instance/formInstance.ts
+++ b/src/api/instance/formInstance.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { postRefresh } from "../login";
-import useTokenStore from "@/store/useTokenStore";
+import useTokenStore, { TOKEN_KEY } from "@/store/useTokenStore";
 
 const baseURL = `${import.meta.env.VITE_API_URL}`;
 
@@ -13,7 +13,7 @@ const formInstance = axios.create({
 
 formInstance.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem("token");
+    const token = localStorage.getItem(TOKEN_KEY);
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }

--- a/src/api/instance/formInstance.ts
+++ b/src/api/instance/formInstance.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { postRefresh } from "../login";
-import useTokenStore, { TOKEN_KEY } from "@/store/useTokenStore";
+import useTokenStore from "@/store/useTokenStore";
 
 const baseURL = `${import.meta.env.VITE_API_URL}`;
 
@@ -13,7 +13,7 @@ const formInstance = axios.create({
 
 formInstance.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem(TOKEN_KEY);
+    const token = useTokenStore.getState().token;
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }

--- a/src/api/instance/formInstance.ts
+++ b/src/api/instance/formInstance.ts
@@ -1,5 +1,6 @@
-import { TOKEN_KEY } from "@/store/useTokenStore";
 import axios from "axios";
+import { postRefresh } from "../login";
+import useTokenStore from "@/store/useTokenStore";
 
 const baseURL = `${import.meta.env.VITE_API_URL}`;
 
@@ -12,13 +13,37 @@ const formInstance = axios.create({
 
 formInstance.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem(TOKEN_KEY);
+    const token = localStorage.getItem("token");
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
     return config;
   },
   (error) => {
+    return Promise.reject(error);
+  },
+);
+
+formInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      try {
+        const response: { accessToken: string } = await postRefresh();
+        const newToken = response.accessToken;
+        useTokenStore.getState().setToken(newToken);
+
+        originalRequest.headers.Authorization = `Bearer ${newToken}`;
+        return formInstance(originalRequest);
+      } catch (refreshError) {
+        return Promise.reject(refreshError);
+      }
+    }
+
     return Promise.reject(error);
   },
 );

--- a/src/api/instance/formInstance.ts
+++ b/src/api/instance/formInstance.ts
@@ -40,6 +40,8 @@ formInstance.interceptors.response.use(
         originalRequest.headers.Authorization = `Bearer ${newToken}`;
         return formInstance(originalRequest);
       } catch (refreshError) {
+        alert("토큰 갱신에 실패했다옹... 로그아웃 하고 다시 로그인 해보라냥");
+        window.location.href = "/login";
         return Promise.reject(refreshError);
       }
     }

--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -1,4 +1,3 @@
-import authInstance from "./instance/authInstance";
 import defaultInstance from "./instance/defaultInstance";
 
 export const getKakaoUrl = async () => {
@@ -29,7 +28,7 @@ export const postLogin = async (kakaoId: number) => {
 };
 
 export const postRefresh = async () => {
-  const response = await authInstance.post("/auth/refresh", null, {
+  const response = await defaultInstance.post("/auth/refresh", null, {
     withCredentials: true,
   });
   return response.data;

--- a/src/api/queries/loginQueries.ts
+++ b/src/api/queries/loginQueries.ts
@@ -1,6 +1,6 @@
 import { queryOptions } from "@tanstack/react-query";
 import { IKakaoAuthResponse, ILoginCode, ILoginResponse } from "@/api/types";
-import { getKakaoId, getKakaoUrl, postLogin, postRefresh } from "@/api/login";
+import { getKakaoId, getKakaoUrl, postLogin } from "@/api/login";
 import { NavigateFunction } from "react-router-dom";
 
 export const loginQueries = {
@@ -51,21 +51,6 @@ export const loginQueries = {
     onError: (error: Error) => {
       console.error("Login failed:", error);
       alert("로그인에 실패했다옹... 다시 시도해달라옹");
-    },
-  }),
-
-  refresh: ({
-    setToken,
-    onRefreshSuccess,
-  }: {
-    setToken: (token: string) => void;
-    onRefreshSuccess?: () => void;
-  }) => ({
-    mutationKey: [...loginQueries.all(), "refresh"],
-    mutationFn: () => postRefresh(),
-    onSuccess: (data: ILoginResponse) => {
-      setToken(data.accessToken);
-      onRefreshSuccess?.();
     },
   }),
 };

--- a/src/api/queries/postQueries.ts
+++ b/src/api/queries/postQueries.ts
@@ -25,7 +25,7 @@ export const postQueries = {
       queryFn: () => getPostDetail(postId),
     }),
 
-  create: ({ refresh }: { refresh: () => void }) => ({
+  create: () => ({
     mutationKey: [...postQueries.all(), "create"],
     mutationFn: ({ images, content, emotion }: ICreatePost) =>
       postPost({
@@ -34,22 +34,14 @@ export const postQueries = {
         emotion,
       }),
     onError: (error: AxiosError<IError>) => {
-      if (error.response?.status === 401) {
-        refresh();
-        return;
-      } else {
-        alert("게시글 작성에 실패했다옹. 잠시 후 다시 시도해보라냥");
+      if (error.response?.status !== 401) {
+        alert("게시글 작성에 실패했다옹. 잠시 후 다시 시도해보냥");
+        console.log("error", error);
       }
     },
   }),
 
-  like: ({
-    refresh,
-    onLikeSuccess,
-  }: {
-    refresh: () => void;
-    onLikeSuccess?: () => void;
-  }) => ({
+  like: ({ onLikeSuccess }: { onLikeSuccess?: () => void }) => ({
     mutationKey: [...postQueries.all(), "like"],
     mutationFn: ({ postId, isLiked }: { postId: number; isLiked: boolean }) =>
       postLikePost({ postId, isLiked }),
@@ -58,9 +50,7 @@ export const postQueries = {
       onLikeSuccess?.();
     },
     onError: (error: AxiosError<IError>) => {
-      if (error.response?.status === 401) {
-        refresh();
-      } else {
+      if (error.response?.status !== 401) {
         alert("좋아요에 실패했다옹...");
       }
     },

--- a/src/app/MainPage.tsx
+++ b/src/app/MainPage.tsx
@@ -3,45 +3,16 @@ import { IPostContent } from "@/components/common/PostCard/PostContent";
 import { IUserItem } from "@/components/common/UserItem";
 import { IPostSummaryData } from "@/api/types";
 import { IPostFooter } from "@/components/common/PostCard/PostFooter";
-import { useRef, useEffect } from "react";
+import { useRef } from "react";
 import { useObserver } from "@/hooks/common/useObserver";
-import {
-  useInfiniteQuery,
-  useMutation,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { postQueries } from "@/api/queries/postQueries";
-import { AxiosError } from "axios";
-import { loginQueries } from "@/api/queries/loginQueries";
-import useTokenStore from "@/store/useTokenStore";
 
 export default function MainPage() {
-  const { setToken } = useTokenStore();
-  const queryClient = useQueryClient();
-  const { mutate: refresh } = useMutation({
-    ...loginQueries.refresh({
-      setToken,
-      onRefreshSuccess: () => {
-        queryClient.invalidateQueries({
-          queryKey: [...postQueries.all(), "list"],
-        });
-      },
-    }),
-  });
   const { data, fetchNextPage, hasNextPage, isLoading, error } =
     useInfiniteQuery({
       ...postQueries.list(),
     });
-
-  useEffect(() => {
-    if (error instanceof AxiosError) {
-      if (error.response?.status === 401) {
-        refresh();
-      } else {
-        alert("게시글을 불러오는데 실패했다옹...");
-      }
-    }
-  }, [error, refresh]);
 
   const lastElementRef = useRef<HTMLDivElement | null>(null);
   useObserver({

--- a/src/components/common/PostCard/PostFooter.tsx
+++ b/src/components/common/PostCard/PostFooter.tsx
@@ -1,7 +1,5 @@
-import { loginQueries } from "@/api/queries/loginQueries";
 import { postQueries } from "@/api/queries/postQueries";
 import { Button } from "@/components/ui/button";
-import useTokenStore from "@/store/useTokenStore";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
@@ -20,19 +18,9 @@ export default function PostFooter({
 }: IPostFooter) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { setToken } = useTokenStore();
 
-  const { mutate: refresh } = useMutation({
-    ...loginQueries.refresh({
-      setToken,
-      onRefreshSuccess: () => {
-        likePost({ postId, isLiked: didLike });
-      },
-    }),
-  });
   const { mutate: likePost, isPending } = useMutation({
     ...postQueries.like({
-      refresh,
       onLikeSuccess: () => {
         queryClient.invalidateQueries({
           queryKey: [...postQueries.all(), "detail", postId],

--- a/src/components/pages/PostForm/CreatePostForm.tsx
+++ b/src/components/pages/PostForm/CreatePostForm.tsx
@@ -8,30 +8,15 @@ import { useImageUpload } from "@/hooks/common/useImageUpload";
 import { ApiEmotion } from "@/types/Emotion";
 import { postQueries } from "@/api/queries/postQueries";
 import { useMutation } from "@tanstack/react-query";
-import { loginQueries } from "@/api/queries/loginQueries";
-import useTokenStore from "@/store/useTokenStore";
 
 export default function CreatePostForm() {
   const navigate = useNavigate();
-  const { setToken } = useTokenStore();
-  const { mutate: refresh } = useMutation({
-    ...loginQueries.refresh({
-      setToken,
-      onRefreshSuccess: () => {
-        createPost({
-          images: selectedImages.map((img) => img.file),
-          content,
-          emotion: selectedEmotion,
-        });
-      },
-    }),
-  });
   const {
     mutate: createPost,
     isPending,
     isSuccess,
     isError,
-  } = useMutation({ ...postQueries.create({ refresh }) });
+  } = useMutation({ ...postQueries.create() });
 
   const { selectedImages, addImages, removeImage, error } = useImageUpload();
   const [content, setContent] = useState("");


### PR DESCRIPTION
## 🚀 작업 내용

- token 재발급하는 요청을 interceptor에서 수행하도록 수정함

## ✨ 작업 상세 설명

- token이 만료되는 경우, `onError` 시에 콜백으로 refresh 이후 재시도 => 재시도까지 오래 걸린다는 문제 발견
- 추가로 refresh 요청을 위한 `Mutation`이나 `setToken` 선언이 불필요하게 많음

## 📌 관련 이슈
- #86 

### 🔥 문제 상황 (선택)

> ![Image](https://github.com/user-attachments/assets/6f252e17-2dc9-4166-920c-bd111bcfc94f)

- 게시글 `token`으로 조회할 때, `token` 만료된 경우 요청을 반복적으로 보내다가 나중에서야 `refresh` 요청을 보냄
- 기존에는 `useEffect`로 error 시에 `refresh` 하도록 되어있었음

### 💦 해결 방법 (선택)

![5 23 게시글 조회 오래걸리는 이슈 해결](https://github.com/user-attachments/assets/9fcf3f04-6623-4006-903f-db5b98f85856)

- `interceptor`에서 `response error`의 `status code`가 `401`인 경우에 `refresh` 요청을 보내고, 원래 요청을 재시도 하도록 수정
- 변경 후에는 한번만 요청 실패하고 바로 refresh 요청 후 재시도 => 불필요한 API 호출 수를 줄임

## 💬 추후 수정해야 하는 부분 및 기타 논의 사항 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
