### PR TITLE
style: 댓글 입력창 로딩 애니메이션 추가

### DIFF
--- a/src/components/pages/Comment/CommentInput.tsx
+++ b/src/components/pages/Comment/CommentInput.tsx
@@ -51,13 +51,19 @@ export default function CommentInput({ postId }: ICommentInput) {
   return (
     <div className="w-[90%] flex gap-2 bg-orange-100 rounded-lg py-2 px-3 fixed bottom-16 max-w-[400px] sm:mx-auto shadow-lg border border-foreground/20">
       <div className="w-full flex flex-col gap-2">
-        <textarea
-          value={value}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          placeholder="댓글을 입력하세야옹..."
-          className="w-full resize-none flex-1 text-sm rounded-sm"
-        />
+        <div className="relative w-full h-full">
+          <textarea
+            value={value}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            placeholder="댓글을 입력하세야옹..."
+            className={cn(
+              "w-full h-full resize-none flex-1 text-sm rounded-sm px-1",
+              isPending && "animate-pulse bg-muted-foreground",
+            )}
+            disabled={isPending}
+          />
+        </div>
       </div>
       <div className="flex flex-row items-center gap-1">
         <span


### PR DESCRIPTION
## 🚀 작업 내용

- 댓글 입력에 대해 isPending인 경우 입력창 disabled 되고 창에 pulse로 갈색 깜빡이도록

## ✨ 작업 상세 설명

- 댓글 입력시 응답 기다릴 때 까지 로딩 애니메이션

![댓글 입력창 로딩 애니메이션](https://github.com/user-attachments/assets/9bab4b30-1345-4b8d-ae08-2a08d3f7e62e)

## 📌 관련 이슈
- 없음

### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 💬 추후 수정해야 하는 부분 및 기타 논의 사항 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
