### PR TITLE
feat: 프로필 편집 기능 구현

### DIFF
--- a/src/api/image.ts
+++ b/src/api/image.ts
@@ -24,5 +24,6 @@ export const uploadImageToS3 = async ({
     throw new Error("이미지 업로드 실패");
   }
 
-  return data.key;
+  const cloudFrontUrl = import.meta.env.VITE_CLOUDFRONT_URL;
+  return `${cloudFrontUrl}${data.key}`;
 };

--- a/src/api/queries/ImageQueries.ts
+++ b/src/api/queries/ImageQueries.ts
@@ -12,7 +12,10 @@ export const imageQueries = {
     File
   > => ({
     mutationKey: [...imageQueries.all(), "getPreSignedUrl"],
-    mutationFn: (file: File) => uploadImageToS3({ file }),
+    mutationFn: async (file: File) => {
+      const url = await uploadImageToS3({ file });
+      return url;
+    },
     onError: (error: AxiosError<IError>) => {
       if (error.response?.status !== 401) {
         alert("이미지 업로드에 실패했다옹. 잠시 후 다시 시도해보냥");

--- a/src/api/queries/ImageQueries.ts
+++ b/src/api/queries/ImageQueries.ts
@@ -11,7 +11,7 @@ export const imageQueries = {
     AxiosError<IError>,
     File
   > => ({
-    mutationKey: [...imageQueries.all(), "getPreSignedUrl"],
+    mutationKey: [...imageQueries.all(), "uploadImageToS3"],
     mutationFn: async (file: File) => {
       const url = await uploadImageToS3({ file });
       return url;

--- a/src/api/queries/userQueries.ts
+++ b/src/api/queries/userQueries.ts
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-query";
 import {
   deleteFollow,
+  getEditProfileInfo,
   getFollowerList,
   getFollowingList,
   getProfileInfo,
@@ -14,6 +15,7 @@ import {
   postFollow,
 } from "../user";
 import {
+  IEditProfileInfoResponse,
   IFollowerDataPagination,
   IProfileInfoResponse,
   IUserIdResponse,
@@ -42,6 +44,11 @@ export const userQueries = {
   }): UseQueryOptions<IProfileInfoResponse, Error> => ({
     queryKey: [...userQueries.all(), "profileInfo", userId],
     queryFn: () => getProfileInfo({ userId }),
+  }),
+
+  editProfileInfo: (): UseQueryOptions<IEditProfileInfoResponse, Error> => ({
+    queryKey: [...userQueries.all(), "editProfileInfo"],
+    queryFn: getEditProfileInfo,
   }),
 
   follow: ({

--- a/src/api/queries/userQueries.ts
+++ b/src/api/queries/userQueries.ts
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-query";
 import {
   deleteFollow,
+  editProfile,
   getEditProfileInfo,
   getFollowerList,
   getFollowingList,
@@ -16,6 +17,7 @@ import {
 } from "../user";
 import {
   IEditProfileInfoResponse,
+  IEditProfileRequest,
   IFollowerDataPagination,
   IProfileInfoResponse,
   IUserIdResponse,
@@ -23,6 +25,7 @@ import {
 } from "../types/user";
 import { IError } from "../types/common";
 import { AxiosError } from "axios";
+import { NavigateFunction } from "react-router-dom";
 
 export const userQueries = {
   all: () => ["user"] as const,
@@ -49,6 +52,23 @@ export const userQueries = {
   editProfileInfo: (): UseQueryOptions<IEditProfileInfoResponse, Error> => ({
     queryKey: [...userQueries.all(), "editProfileInfo"],
     queryFn: getEditProfileInfo,
+  }),
+
+  editProfile: ({
+    navigate,
+  }: {
+    navigate: NavigateFunction;
+  }): UseMutationOptions<
+    IEditProfileInfoResponse,
+    AxiosError<IError>,
+    IEditProfileRequest
+  > => ({
+    mutationKey: [...userQueries.all(), "editProfile"],
+    mutationFn: (data) => editProfile(data),
+    onSuccess: () => {
+      alert("프로필 수정에 성공했다옹...");
+      navigate("/mypage/redirect");
+    },
   }),
 
   follow: ({

--- a/src/api/queries/userQueries.ts
+++ b/src/api/queries/userQueries.ts
@@ -56,8 +56,10 @@ export const userQueries = {
 
   editProfile: ({
     navigate,
+    queryClient,
   }: {
     navigate: NavigateFunction;
+    queryClient: QueryClient;
   }): UseMutationOptions<
     IEditProfileInfoResponse,
     AxiosError<IError>,
@@ -67,6 +69,9 @@ export const userQueries = {
     mutationFn: (data) => editProfile(data),
     onSuccess: () => {
       alert("프로필 수정에 성공했다옹...");
+      queryClient.invalidateQueries({
+        queryKey: [...userQueries.all(), "userProfileImage"],
+      });
       navigate("/mypage/redirect");
     },
   }),

--- a/src/api/queries/userQueries.ts
+++ b/src/api/queries/userQueries.ts
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-query";
 import {
   deleteFollow,
+  deleteProfile,
   editProfile,
   getEditProfileInfo,
   getFollowerList,
@@ -73,6 +74,19 @@ export const userQueries = {
         queryKey: [...userQueries.all(), "userProfileImage"],
       });
       navigate("/mypage/redirect");
+    },
+  }),
+
+  deleteProfile: ({
+    navigate,
+  }: {
+    navigate: NavigateFunction;
+  }): UseMutationOptions<void, AxiosError<IError>, void> => ({
+    mutationKey: [...userQueries.all(), "deleteProfile"],
+    mutationFn: () => deleteProfile(),
+    onSuccess: () => {
+      alert("프로필 삭제에 성공했다옹...");
+      navigate("/login");
     },
   }),
 

--- a/src/api/types/user.ts
+++ b/src/api/types/user.ts
@@ -19,6 +19,12 @@ export interface IProfileInfoResponse {
   currentUser: boolean;
 }
 
+export interface IEditProfileInfoResponse {
+  nickname: string;
+  postType: ApiAnimalType;
+  profileImageUrl: string;
+}
+
 export interface IFollowerData {
   userId: number;
   nickname: string;

--- a/src/api/types/user.ts
+++ b/src/api/types/user.ts
@@ -27,7 +27,7 @@ export interface IEditProfileInfoResponse {
 
 export interface IEditProfileRequest {
   nickname: string;
-  profileImageUrl: string;
+  profileImageUrl?: string;
   postType: ApiAnimalType;
 }
 

--- a/src/api/types/user.ts
+++ b/src/api/types/user.ts
@@ -25,6 +25,12 @@ export interface IEditProfileInfoResponse {
   profileImageUrl: string;
 }
 
+export interface IEditProfileRequest {
+  nickname: string;
+  profileImageUrl: string;
+  postType: ApiAnimalType;
+}
+
 export interface IFollowerData {
   userId: number;
   nickname: string;

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -2,6 +2,7 @@ import authInstance from "./instance/authInstance";
 import defaultInstance from "./instance/defaultInstance";
 import {
   IEditProfileInfoResponse,
+  IEditProfileRequest,
   IFollowerDataPagination,
   IProfileInfoResponse,
   IUserIdResponse,
@@ -31,6 +32,19 @@ export const getEditProfileInfo = async () => {
   const response = await authInstance.get<IEditProfileInfoResponse>(
     "/users/edit-profile",
   );
+  return response.data;
+};
+
+export const editProfile = async ({
+  nickname,
+  profileImageUrl,
+  postType,
+}: IEditProfileRequest) => {
+  const response = await authInstance.patch("/users", {
+    nickname,
+    profileImageUrl,
+    postType,
+  });
   return response.data;
 };
 

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -48,6 +48,11 @@ export const editProfile = async ({
   return response.data;
 };
 
+export const deleteProfile = async () => {
+  const response = await authInstance.delete("/users");
+  return response.data;
+};
+
 export const postFollow = async ({ userId }: { userId: number }) => {
   const response = await authInstance.post(`/users/follow/${userId}`);
   return response.data;

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,6 +1,7 @@
 import authInstance from "./instance/authInstance";
 import defaultInstance from "./instance/defaultInstance";
 import {
+  IEditProfileInfoResponse,
   IFollowerDataPagination,
   IProfileInfoResponse,
   IUserIdResponse,
@@ -22,6 +23,13 @@ export const getUserId = async () => {
 export const getProfileInfo = async ({ userId }: { userId: number }) => {
   const response = await authInstance.get<IProfileInfoResponse>(
     `/users/profile/${userId}`,
+  );
+  return response.data;
+};
+
+export const getEditProfileInfo = async () => {
+  const response = await authInstance.get<IEditProfileInfoResponse>(
+    "/users/edit-profile",
   );
   return response.data;
 };

--- a/src/components/common/NavigationBar.tsx
+++ b/src/components/common/NavigationBar.tsx
@@ -27,7 +27,7 @@ export default function NavigationBar() {
       {/* {renderIconButton("/chat", <img src="/icon/chat.svg" alt="chat" />)} */}
       {renderIconButton(
         token ? "/mypage/redirect" : "/login",
-        <Avatar>
+        <Avatar className="border border-muted-foreground">
           <AvatarImage src={profileImage?.profileImageUrl ?? "/logo.svg"} />
           <AvatarFallback>미야옹</AvatarFallback>
         </Avatar>,

--- a/src/components/common/UserItem.tsx
+++ b/src/components/common/UserItem.tsx
@@ -25,7 +25,7 @@ export default function UserItem({
 
   return (
     <div className="flex flex-row items-center gap-2" onClick={handleClick}>
-      <Avatar>
+      <Avatar className="border border-muted-foreground">
         <AvatarImage src={profileImageUrl ?? "/logo.svg"} />
         <AvatarFallback>미야옹</AvatarFallback>
       </Avatar>

--- a/src/components/pages/MemberForm/EditProfileForm.tsx
+++ b/src/components/pages/MemberForm/EditProfileForm.tsx
@@ -13,9 +13,8 @@ export default function EditProfileForm() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const [selectedImage, setSelectedImage] = useState<File | string | null>(
-    null,
-  );
+  const [initialImage, setInitialImage] = useState<string>("");
+  const [selectedImage, setSelectedImage] = useState<File | null>(null);
   const [nicknameValue, setNicknameValue] = useState<string>("");
   const [selectedAnimal, setSelectedAnimal] = useState<ApiAnimalType>(
     ApiAnimalType.CAT,
@@ -39,13 +38,13 @@ export default function EditProfileForm() {
     if (editProfileInfo) {
       setNicknameValue(editProfileInfo.nickname);
       setSelectedAnimal(editProfileInfo.postType);
-      setSelectedImage(editProfileInfo.profileImageUrl);
+      setInitialImage(editProfileInfo.profileImageUrl);
     }
   }, [editProfileInfo]);
 
   const isNicknameChanged = nicknameValue !== editProfileInfo?.nickname;
   const isAnimalChanged = selectedAnimal !== editProfileInfo?.postType;
-  const isImageChanged = selectedImage !== editProfileInfo?.profileImageUrl;
+  const isImageChanged = selectedImage !== null;
   const isSubmitDisabled =
     (isNicknameChanged && isNicknameDuplicate) ||
     (!isNicknameChanged && !isAnimalChanged && !isImageChanged);
@@ -55,11 +54,11 @@ export default function EditProfileForm() {
       const imageUrl =
         selectedImage instanceof File
           ? await uploadImageToS3(selectedImage)
-          : (selectedImage as string);
+          : (initialImage ?? undefined);
 
       editProfile({
         nickname: nicknameValue,
-        profileImageUrl: selectedImage instanceof File ? imageUrl : undefined,
+        profileImageUrl: imageUrl,
         postType: selectedAnimal,
       });
     } catch (error) {
@@ -79,6 +78,7 @@ export default function EditProfileForm() {
       <h2 className="text-4xl">프로필 수정할거냥</h2>
       <ProfileImageSelection
         titleText="친구는 어떻게 생겼냐옹"
+        initialImage={initialImage ?? undefined}
         selectedImage={selectedImage}
         setSelectedImage={setSelectedImage}
       />

--- a/src/components/pages/MemberForm/EditProfileForm.tsx
+++ b/src/components/pages/MemberForm/EditProfileForm.tsx
@@ -51,16 +51,21 @@ export default function EditProfileForm() {
     (!isNicknameChanged && !isAnimalChanged && !isImageChanged);
 
   const handleSubmit = async () => {
-    const imageUrl =
-      selectedImage instanceof File
-        ? await uploadImageToS3(selectedImage)
-        : (selectedImage as string);
+    try {
+      const imageUrl =
+        selectedImage instanceof File
+          ? await uploadImageToS3(selectedImage)
+          : (selectedImage as string);
 
-    editProfile({
-      nickname: nicknameValue,
-      profileImageUrl: selectedImage instanceof File ? imageUrl : undefined,
-      postType: selectedAnimal,
-    });
+      editProfile({
+        nickname: nicknameValue,
+        profileImageUrl: selectedImage instanceof File ? imageUrl : undefined,
+        postType: selectedAnimal,
+      });
+    } catch (error) {
+      alert("프로필 수정에 실패했다옹");
+      console.error(error);
+    }
   };
 
   const handleDeleteProfile = () => {

--- a/src/components/pages/MemberForm/EditProfileForm.tsx
+++ b/src/components/pages/MemberForm/EditProfileForm.tsx
@@ -29,7 +29,7 @@ export default function EditProfileForm() {
   }, [editProfileInfo]);
 
   const isSubmitDisabled =
-    isNicknameDuplicate ||
+    (nicknameValue !== editProfileInfo?.nickname && isNicknameDuplicate) ||
     !nicknameValue.trim() ||
     (nicknameValue === editProfileInfo?.nickname &&
       selectedAnimal === editProfileInfo?.postType &&

--- a/src/components/pages/MemberForm/EditProfileForm.tsx
+++ b/src/components/pages/MemberForm/EditProfileForm.tsx
@@ -1,19 +1,40 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import NicknameInput from "./NicknameInput";
 import ProfileImageSelection from "./ProfileImageSelection";
 import SelectAnimalType from "./SelectAnimalType";
 import { ApiAnimalType } from "@/types/animal";
 import { Button } from "@/components/ui/button";
+import { userQueries } from "@/api/queries/userQueries";
+import { useQuery } from "@tanstack/react-query";
 
 export default function EditProfileForm() {
-  const [selectedImage, setSelectedImage] = useState<File | null>(null);
+  const [selectedImage, setSelectedImage] = useState<File | string | null>(
+    null,
+  );
   const [nicknameValue, setNicknameValue] = useState<string>("");
   const [selectedAnimal, setSelectedAnimal] = useState<ApiAnimalType>(
     ApiAnimalType.CAT,
   );
   const [isNicknameDuplicate, setIsNicknameDuplicate] = useState(true);
+  const { data: editProfileInfo } = useQuery({
+    ...userQueries.editProfileInfo(),
+  });
 
-  const isSubmitDisabled = isNicknameDuplicate || !nicknameValue.trim();
+  useEffect(() => {
+    if (editProfileInfo) {
+      setNicknameValue(editProfileInfo.nickname);
+      setSelectedAnimal(editProfileInfo.postType);
+      setSelectedImage(editProfileInfo.profileImageUrl);
+    }
+  }, [editProfileInfo]);
+
+  const isSubmitDisabled =
+    isNicknameDuplicate ||
+    !nicknameValue.trim() ||
+    (nicknameValue === editProfileInfo?.nickname &&
+      selectedAnimal === editProfileInfo?.postType &&
+      selectedImage === editProfileInfo?.profileImageUrl);
+
   const handleSubmit = () => {
     console.log("submit");
   };

--- a/src/components/pages/MemberForm/EditProfileForm.tsx
+++ b/src/components/pages/MemberForm/EditProfileForm.tsx
@@ -5,12 +5,13 @@ import SelectAnimalType from "./SelectAnimalType";
 import { ApiAnimalType } from "@/types/animal";
 import { Button } from "@/components/ui/button";
 import { userQueries } from "@/api/queries/userQueries";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { imageQueries } from "@/api/queries/ImageQueries";
 
 export default function EditProfileForm() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const [selectedImage, setSelectedImage] = useState<File | string | null>(
     null,
@@ -28,7 +29,7 @@ export default function EditProfileForm() {
     ...imageQueries.uploadImageToS3(),
   });
   const { mutate: editProfile } = useMutation({
-    ...userQueries.editProfile({ navigate }),
+    ...userQueries.editProfile({ navigate, queryClient }),
   });
 
   useEffect(() => {

--- a/src/components/pages/MemberForm/EditProfileForm.tsx
+++ b/src/components/pages/MemberForm/EditProfileForm.tsx
@@ -43,12 +43,12 @@ export default function EditProfileForm() {
     }
   }, [editProfileInfo]);
 
+  const isNicknameChanged = nicknameValue !== editProfileInfo?.nickname;
+  const isAnimalChanged = selectedAnimal !== editProfileInfo?.postType;
+  const isImageChanged = selectedImage !== editProfileInfo?.profileImageUrl;
   const isSubmitDisabled =
-    (nicknameValue !== editProfileInfo?.nickname && isNicknameDuplicate) ||
-    !nicknameValue.trim() ||
-    (nicknameValue === editProfileInfo?.nickname &&
-      selectedAnimal === editProfileInfo?.postType &&
-      selectedImage === editProfileInfo?.profileImageUrl);
+    (isNicknameChanged && isNicknameDuplicate) ||
+    (!isNicknameChanged && !isAnimalChanged && !isImageChanged);
 
   const handleSubmit = async () => {
     const imageUrl =

--- a/src/components/pages/MemberForm/EditProfileForm.tsx
+++ b/src/components/pages/MemberForm/EditProfileForm.tsx
@@ -47,14 +47,14 @@ export default function EditProfileForm() {
       selectedImage === editProfileInfo?.profileImageUrl);
 
   const handleSubmit = async () => {
-    const finalImageUrl =
+    const imageUrl =
       selectedImage instanceof File
         ? await uploadImageToS3(selectedImage)
         : (selectedImage as string);
 
     editProfile({
       nickname: nicknameValue,
-      profileImageUrl: finalImageUrl,
+      profileImageUrl: selectedImage instanceof File ? imageUrl : undefined,
       postType: selectedAnimal,
     });
   };

--- a/src/components/pages/MemberForm/EditProfileForm.tsx
+++ b/src/components/pages/MemberForm/EditProfileForm.tsx
@@ -31,6 +31,9 @@ export default function EditProfileForm() {
   const { mutate: editProfile } = useMutation({
     ...userQueries.editProfile({ navigate, queryClient }),
   });
+  const { mutate: deleteProfile } = useMutation({
+    ...userQueries.deleteProfile({ navigate }),
+  });
 
   useEffect(() => {
     if (editProfileInfo) {
@@ -58,6 +61,12 @@ export default function EditProfileForm() {
       profileImageUrl: selectedImage instanceof File ? imageUrl : undefined,
       postType: selectedAnimal,
     });
+  };
+
+  const handleDeleteProfile = () => {
+    if (window.confirm("정말 탈퇴할거냥?")) {
+      deleteProfile();
+    }
   };
 
   return (
@@ -91,7 +100,9 @@ export default function EditProfileForm() {
           다 적으면 누르라냥
         </Button>
       </div>
-      <Button variant="link">탈퇴할거냥</Button>
+      <Button variant="link" onClick={handleDeleteProfile}>
+        탈퇴할거냥
+      </Button>
     </div>
   );
 }

--- a/src/components/pages/MemberForm/EditProfileForm.tsx
+++ b/src/components/pages/MemberForm/EditProfileForm.tsx
@@ -47,7 +47,10 @@ export default function EditProfileForm() {
       selectedImage === editProfileInfo?.profileImageUrl);
 
   const handleSubmit = async () => {
-    const finalImageUrl = await uploadImageToS3(selectedImage as File);
+    const finalImageUrl =
+      selectedImage instanceof File
+        ? await uploadImageToS3(selectedImage)
+        : (selectedImage as string);
 
     editProfile({
       nickname: nicknameValue,

--- a/src/components/pages/MemberForm/ProfileImageSelection.tsx
+++ b/src/components/pages/MemberForm/ProfileImageSelection.tsx
@@ -5,7 +5,7 @@ import { Label } from "@radix-ui/react-label";
 interface IProfileImageSelection {
   titleText?: string;
   isRequired?: boolean;
-  selectedImage: File | null;
+  selectedImage: File | string | null;
   setSelectedImage: (image: File) => void;
 }
 

--- a/src/components/pages/MemberForm/ProfileImageSelection.tsx
+++ b/src/components/pages/MemberForm/ProfileImageSelection.tsx
@@ -5,18 +5,20 @@ import { Label } from "@radix-ui/react-label";
 interface IProfileImageSelection {
   titleText?: string;
   isRequired?: boolean;
-  selectedImage: File | string | null;
+  initialImage?: string;
+  selectedImage: File | null;
   setSelectedImage: (image: File) => void;
 }
 
 export default function ProfileImageSelection({
   titleText,
   isRequired = false,
+  initialImage,
   selectedImage,
   setSelectedImage,
 }: IProfileImageSelection) {
   const { previewUrl, createPreview } = useImagePreview({
-    initialImage: selectedImage,
+    initialImage: initialImage ?? selectedImage,
   });
 
   const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/components/pages/MemberForm/SelectAnimalType.tsx
+++ b/src/components/pages/MemberForm/SelectAnimalType.tsx
@@ -33,14 +33,11 @@ export default function SelectAnimalType({
       <RadioGroup
         value={selectedAnimal}
         className="flex flex-row gap-2 flex-wrap"
+        onValueChange={handleAnimalChange}
       >
         {animals.map((animal, index) => (
           <div key={animal} className="flex items-center space-x-2">
-            <RadioGroupItem
-              value={animal}
-              id={`${animal}-${index + 1}`}
-              onClick={() => handleAnimalChange(animal)}
-            />
+            <RadioGroupItem value={animal} id={`${animal}-${index + 1}`} />
             <Label htmlFor={`r${index + 1}`} className="text-lg">
               {convertAnimalTypeToDisplay(animal)}
             </Label>

--- a/src/components/pages/MemberForm/SelectAnimalType.tsx
+++ b/src/components/pages/MemberForm/SelectAnimalType.tsx
@@ -31,7 +31,7 @@ export default function SelectAnimalType({
         </Label>
       )}
       <RadioGroup
-        defaultValue={selectedAnimal}
+        value={selectedAnimal}
         className="flex flex-row gap-2 flex-wrap"
       >
         {animals.map((animal, index) => (

--- a/src/components/pages/MemberForm/validation/validateNickname.ts
+++ b/src/components/pages/MemberForm/validation/validateNickname.ts
@@ -2,7 +2,9 @@ import { ValidationReturnType } from "@/types/ValidationReturnType";
 
 export const validateNickname = (nickname: string): ValidationReturnType => {
   const emojiRegex = /[\p{Emoji}]/u;
-  if (emojiRegex.test(nickname)) {
+  if (!nickname.trim()) {
+    return { isValid: false, message: "닉네임을 입력해주세요" };
+  } else if (emojiRegex.test(nickname)) {
     return { isValid: false, message: "이모지 없이 적어달라옹" };
   } else if (nickname.length < 3) {
     return { isValid: false, message: "닉네임은 3자 이상이어야 한다옹" };

--- a/src/components/pages/MemberPage/ProfileSummary.tsx
+++ b/src/components/pages/MemberPage/ProfileSummary.tsx
@@ -24,6 +24,17 @@ export default function ProfileSummary({ userId }: IProfileSummary) {
     ...userQueries.unfollow({ userId, queryClient }),
   });
 
+  const handleShareClick = async () => {
+    const url = `${window.location.origin}/member/${userId}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      alert("링크를 클립보드에 복사했다냥.");
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (error) {
+      alert("링크 복사에 실패했다옹...");
+    }
+  };
+
   return (
     <div className="w-full flex flex-col gap-4 items-center">
       <MemberInfoSummary
@@ -55,7 +66,11 @@ export default function ProfileSummary({ userId }: IProfileSummary) {
             {profileInfo?.following ? "팔로잉" : "팔로우"}
           </Button>
         )}
-        <Button variant="primarySolid" className="w-36 text-lg">
+        <Button
+          variant="primarySolid"
+          className="w-36 text-lg"
+          onClick={handleShareClick}
+        >
           프로필 공유
         </Button>
       </div>

--- a/src/components/pages/MemberPage/ProfileSummary/MemberInfoSummary.tsx
+++ b/src/components/pages/MemberPage/ProfileSummary/MemberInfoSummary.tsx
@@ -15,7 +15,7 @@ export default function MemberInfoSummary({
 }: IMemberInfoSummary) {
   return (
     <div className="flex flex-col items-center gap-2 mt-10">
-      <Avatar className="size-20">
+      <Avatar className="size-20 border border-muted-foreground">
         <AvatarImage src={profileImageUrl ?? "/logo.svg"} />
         <AvatarFallback>미야옹</AvatarFallback>
       </Avatar>

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -26,7 +26,7 @@ function AvatarImage({
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
-      className={cn("aspect-square size-full", className)}
+      className={cn("aspect-square size-full object-cover", className)}
       {...props}
     />
   );

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -11,8 +11,8 @@ function Avatar({
     <AvatarPrimitive.Root
       data-slot="avatar"
       className={cn(
-        "relative flex size-8 shrink-0 overflow-hidden rounded-full bg-orange-950",
-        className
+        "relative flex size-8 shrink-0 overflow-hidden rounded-full",
+        className,
       )}
       {...props}
     />
@@ -41,7 +41,7 @@ function AvatarFallback({
       data-slot="avatar-fallback"
       className={cn(
         "flex size-full items-center justify-center rounded-full bg-orange-950 text-orange-50",
-        className
+        className,
       )}
       {...props}
     />

--- a/src/hooks/common/useImagePreview.ts
+++ b/src/hooks/common/useImagePreview.ts
@@ -1,15 +1,20 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 interface IUseImagePreview {
-  initialImage: File | null;
+  initialImage: File | string | null;
 }
 
 export const useImagePreview = ({ initialImage }: IUseImagePreview) => {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
-  const createPreview = (file: File | null) => {
+  const createPreview = (file: File | string | null) => {
     if (!file) {
       setPreviewUrl(null);
+      return;
+    }
+
+    if (typeof file === "string") {
+      setPreviewUrl(file);
       return;
     }
 
@@ -20,9 +25,11 @@ export const useImagePreview = ({ initialImage }: IUseImagePreview) => {
     reader.readAsDataURL(file);
   };
 
-  if (initialImage) {
-    createPreview(initialImage);
-  }
+  useEffect(() => {
+    if (initialImage) {
+      createPreview(initialImage);
+    }
+  }, [initialImage]);
 
   return {
     previewUrl,

--- a/src/hooks/common/useImageUpload.ts
+++ b/src/hooks/common/useImageUpload.ts
@@ -43,10 +43,8 @@ export const useImageUpload = () => {
     try {
       const imageUrls = await Promise.all(
         selectedImages.map(async (image) => {
-          const key = await uploadImageToS3(image.file);
-
-          const cloudFrontUrl = import.meta.env.VITE_CLOUDFRONT_URL;
-          return `${cloudFrontUrl}${key}`;
+          const imageUrl = await uploadImageToS3(image.file);
+          return imageUrl;
         }),
       );
 


### PR DESCRIPTION
## 🚀 작업 내용
- 프로필 편집 API 연결

## ✨ 작업 상세 설명

- 프로필 편집 기능 구현
  - 이미지 S3에 업로드 후 string으로 보냄
  - 이미지 수정 안된 경우에는 해당 내용(이미지) 빼고 요청
- 프로필 공유 기능 구현 (클립보드에 링크 복사)
- style
  - 프로필 이미지에 옅은 갈색의 테두리 추가 (Avatar 컴포넌트에 추가함)
  - 프로필 이미지 깨져보이는 오류 수정함
## 📌 관련 이슈
- #147 

### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 💬 추후 수정해야 하는 부분 및 기타 논의 사항 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
- S3 활용하는 코드가 혼란스럽습니다. URL을 return 해서 `imageQueries` 에 있는 `mutation option`에서 비동기로 반환해주게 되고, 사용처에서는 `mutateAsync`를 활용하는데 이 과정이 괜찮은지 잘 모르겠습니다... 스스로 공부해보고 고민해보는 것이 좋을까요?