### PR TITLE
fix: 다른 사용자 프로필 조회 안되는 오류 수정

### DIFF
--- a/src/api/types/post.ts
+++ b/src/api/types/post.ts
@@ -22,7 +22,6 @@ export interface IPostDetailData {
   updatedAt: string;
   liked: boolean;
   myPost: boolean;
-  following: boolean;
 }
 
 export interface IPostSummaryData {
@@ -40,7 +39,6 @@ export interface IPostSummaryData {
   updatedAt: string;
   liked: boolean;
   myPost: boolean;
-  following: boolean;
 }
 
 export interface IPostSummaryDataPagination {

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -22,7 +22,7 @@ export const getUserId = async () => {
 };
 
 export const getProfileInfo = async ({ userId }: { userId: number }) => {
-  const response = await authInstance.get<IProfileInfoResponse>(
+  const response = await defaultInstance.get<IProfileInfoResponse>(
     `/users/profile/${userId}`,
   );
   return response.data;

--- a/src/app/MainPage.tsx
+++ b/src/app/MainPage.tsx
@@ -66,7 +66,6 @@ export default function MainPage() {
                 userInfo={userInfo}
                 isMyPost={post.myPost}
                 postId={post.id}
-                isFollowing={post.following}
               />
               <PostCard.Content {...postContent} />
               <PostCard.Footer {...postInfo} />

--- a/src/app/detail/[postId]/DetailPostPage.tsx
+++ b/src/app/detail/[postId]/DetailPostPage.tsx
@@ -55,7 +55,6 @@ function DetailPostPage() {
               }}
               isMyPost={data.myPost}
               postId={Number(postId)}
-              isFollowing={data.following}
             />
             {data.imageUrls.length > 0 && (
               <ImageCarousel images={data.imageUrls} />

--- a/src/components/common/PostCard/PostHeader.tsx
+++ b/src/components/common/PostCard/PostHeader.tsx
@@ -1,65 +1,21 @@
 import ContextMenu from "./ContextMenu";
 import UserItem, { IUserItem } from "../UserItem";
-import { Button } from "@/components/ui/button";
-import { userQueries } from "@/api/queries/userQueries";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { postQueries } from "@/api/queries/postQueries";
 
 interface IPostHeader {
   userInfo: IUserItem;
   isMyPost: boolean;
   postId: number;
-  isFollowing?: boolean;
 }
 
 export default function PostHeader({
   userInfo,
   isMyPost,
   postId,
-  isFollowing,
 }: IPostHeader) {
-  const queryClient = useQueryClient();
-  const { mutate: follow } = useMutation({
-    ...userQueries.follow({ userId: userInfo.userId, queryClient }),
-  });
-  const { mutate: unfollow } = useMutation({
-    ...userQueries.unfollow({ userId: userInfo.userId, queryClient }),
-  });
-
-  const handleFollowClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (isFollowing) {
-      unfollow();
-      queryClient.invalidateQueries({
-        queryKey: [...postQueries.all()],
-      });
-    } else {
-      follow();
-      queryClient.invalidateQueries({
-        queryKey: [...postQueries.all()],
-      });
-    }
-  };
-
   return (
     <div className="flex flex-row items-center justify-between w-full">
-      <div className="flex flex-row items-center gap-3">
-        <UserItem {...userInfo} />
-      </div>
-      {isMyPost ? (
-        <ContextMenu postId={postId} />
-      ) : (
-        isFollowing !== undefined && (
-          <Button
-            variant={isFollowing ? "primarySolid" : "primaryOutline"}
-            size="sm"
-            className="border-muted-foreground text-xs p-2 h-5"
-            onClick={handleFollowClick}
-          >
-            {isFollowing ? "팔로잉" : "팔로우"}
-          </Button>
-        )
-      )}
+      <UserItem {...userInfo} />
+      {isMyPost && <ContextMenu postId={postId} />}
     </div>
   );
 }


### PR DESCRIPTION
## 🚀 작업 내용
- 로그인 안 했을 때 다른 사용자 프로필 조회 안되는 오류 수정 (`authInstance` -> `defaultInstance`)
- 게시글에 팔로우 버튼 제거하기로 팀 내에서 결정되어서 revert 수행
## ✨ 작업 상세 설명

## 📌 관련 이슈
- 이슈 번호

### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 💬 추후 수정해야 하는 부분 및 기타 논의 사항 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
