### PR TITLE
fix: 게시글 수정/삭제 시의 오류 수정

### DIFF
--- a/src/api/queries/postQueries.ts
+++ b/src/api/queries/postQueries.ts
@@ -18,6 +18,7 @@ import {
 } from "../post";
 import {
   infiniteQueryOptions,
+  QueryClient,
   queryOptions,
   UseMutationOptions,
 } from "@tanstack/react-query";
@@ -92,15 +93,20 @@ export const postQueries = {
 
   delete: ({
     postId,
-    navigate,
+    queryClient,
   }: {
     postId: number;
-    navigate: NavigateFunction;
+    queryClient: QueryClient;
   }) => ({
     mutationKey: [...postQueries.all(), "delete", postId],
     mutationFn: () => deletePost(postId),
     onSuccess: () => {
-      navigate(0);
+      queryClient.invalidateQueries({
+        queryKey: [...postQueries.all(), "list"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [...postQueries.all(), "userPostList"],
+      });
     },
     onError: (error: AxiosError<IError>) => {
       if (error.response?.status !== 401) {

--- a/src/api/queries/postQueries.ts
+++ b/src/api/queries/postQueries.ts
@@ -100,7 +100,7 @@ export const postQueries = {
     mutationKey: [...postQueries.all(), "delete", postId],
     mutationFn: () => deletePost(postId),
     onSuccess: () => {
-      navigate("/");
+      navigate(0);
     },
     onError: (error: AxiosError<IError>) => {
       if (error.response?.status !== 401) {

--- a/src/components/common/PostCard/ContextMenu.tsx
+++ b/src/components/common/PostCard/ContextMenu.tsx
@@ -1,15 +1,16 @@
 import { useState } from "react";
 import { Button } from "../../ui/button";
 import { useNavigate } from "react-router-dom";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { postQueries } from "@/api/queries/postQueries";
 import DotsVerticalIcon from "@/assets/icon/dots-vertical.svg?react";
 
 export default function ContextMenu({ postId }: { postId: number }) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const { mutate: deletePost } = useMutation({
-    ...postQueries.delete({ postId, navigate }),
+    ...postQueries.delete({ postId, queryClient }),
   });
 
   const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/src/hooks/common/useImageUpload.ts
+++ b/src/hooks/common/useImageUpload.ts
@@ -43,6 +43,10 @@ export const useImageUpload = () => {
     try {
       const imageUrls = await Promise.all(
         selectedImages.map(async (image) => {
+          if (image.file.size === 0 && image.preview.startsWith("http")) {
+            return image.preview;
+          }
+
           const imageUrl = await uploadImageToS3(image.file);
           return imageUrl;
         }),


### PR DESCRIPTION
## 🚀 작업 내용
- 게시글 수정시 이미지 업로드 오류 수정
- 게시글 삭제시 페이지 이동되는 오류 수정
## ✨ 작업 상세 설명
- 게시글 수정 요청을 보낼 때 기존에 있던 URL로 되어있는 이미지도 S3에 올라가면서 빈 파일이 올라가게 됨 => URL로 되어있는 이미지는 URL 그대로 갖고 수정 요청 보낼 수 있도록 수정함
- 게시글 삭제 요청 완료하면 어디에 있던지 메인 페이지로 이동했음 => query key 무효화로 쿼리만 다시 불러오도록 수정함
## 📌 관련 이슈
- #173 

### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 💬 추후 수정해야 하는 부분 및 기타 논의 사항 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
