### PR TITLE
fix: 에러 메시지 수정

### DIFF
--- a/src/api/utils/errorHandler.ts
+++ b/src/api/utils/errorHandler.ts
@@ -7,7 +7,7 @@ export const ERROR_MESSAGES = {
 } as const;
 
 export const ALERT_MESSAGES = {
-  LOGIN_REQUIRED: "로그인 해야 좋아요 누를 수 있다옹. 로그인 하겠냥?",
+  LOGIN_REQUIRED: "로그인 해야 가능하다옹. 로그인 하겠냥?",
   FOLLOW_FAILED: "팔로우에 실패했다옹... 잠시 후 다시 시도해보라냥",
   UNFOLLOW_FAILED: "언팔로우에 실패했다옹... 잠시 후 다시 시도해보라냥",
   LIKE_FAILED: "좋아요에 실패했다옹... 잠시 후 다시 시도해보라냥",


### PR DESCRIPTION
## 🚀 작업 내용

- 에러 메시지 수정
## ✨ 작업 상세 설명
- auth 에러에 대해서 로그인 안했을때 뜨는 alert 메시지가 "로그인 해야 좋아요가 가능하다" 라고 통일되어있었음
  => "로그인 해야 가능하다"고 수정함
## 📌 관련 이슈
- 없음

### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 💬 추후 수정해야 하는 부분 및 기타 논의 사항 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
