### PR TITLE
refactor: 무한 스크롤 최적화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
+        "@tanstack/react-virtual": "^3.13.10",
         "@types/node": "^22.15.3",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
@@ -2255,6 +2256,35 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "zustand": "^5.0.3"
   },
   "devDependencies": {
+    "@tanstack/react-virtual": "^3.13.10",
     "@eslint/js": "^9.22.0",
     "@types/node": "^22.15.3",
     "@types/react": "^19.0.10",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { useRef } from "react";
 import MainPage from "./app/MainPage";
 import CreatePostPage from "./app/create/CreatePostPage";
 import DetailPostPage from "./app/detail/[postId]/DetailPostPage";
@@ -24,15 +25,23 @@ import ChatPage from "./app/chat/ChatPage";
 const queryClient = new QueryClient();
 
 function App() {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
   return (
     <QueryClientProvider client={queryClient}>
       <Router>
         <Background>
           <div className="relative w-full flex flex-col bg-background max-w-[430px] mx-auto outline outline-foreground/20 shadow-xl overflow-y-hidden">
             <Header />
-            <div className="flex-1 overflow-y-auto mb-12">
+            <div
+              ref={scrollContainerRef}
+              className="flex-1 overflow-y-auto mb-12"
+            >
               <Routes>
-                <Route path="/" element={<MainPage />} />
+                <Route
+                  path="/"
+                  element={<MainPage scrollContainerRef={scrollContainerRef} />}
+                />
                 <Route path="/create" element={<CreatePostPage />} />
                 <Route path="/detail/:postId" element={<DetailPostPage />} />
                 <Route path="/edit/:postId" element={<PostEdit />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,7 +79,7 @@ function App() {
                 <Route path="*" element={<NotFoundPage />} />
               </Routes>
             </div>
-            <NavigationBar />
+            <NavigationBar scrollContainerRef={scrollContainerRef} />
           </div>
         </Background>
       </Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,7 +50,10 @@ function App() {
                   element={<MyPageRedirectPage />}
                 />
                 <Route path="/mypage/edit" element={<ProfileEditPage />} />
-                <Route path="/member/:userId" element={<MemberPage />} />
+                <Route
+                  path="/member/:userId"
+                  element={<MemberPage scrollContainerRef={scrollContainerRef} />}
+                />
                 <Route
                   path="/member/:userId/follower"
                   element={<FollowerPage />}

--- a/src/app/MainPage.tsx
+++ b/src/app/MainPage.tsx
@@ -71,6 +71,17 @@ export default function MainPage({ scrollContainerRef }: IMainPage) {
     }
   }, [data, allPosts.length, rowVirtualizer]);
 
+  useEffect(() => {
+    // 새로고침 시 세션 스토리지에 기록된 페이지 스크롤 위치 삭제
+    window.addEventListener("pagehide", () => {
+      sessionStorage.removeItem("scrollIndex");
+    });
+    return () =>
+      window.removeEventListener("pagehide", () => {
+        sessionStorage.removeItem("scrollIndex");
+      });
+  }, []);
+
   // TODO: 로딩 스켈레톤 추가
   if (isPending) {
     return <div>Loading...</div>;

--- a/src/app/MainPage.tsx
+++ b/src/app/MainPage.tsx
@@ -100,6 +100,7 @@ export default function MainPage({ scrollContainerRef }: IMainPage) {
                 style={{ transform: `translateY(${virtualRow.start}px)` }}
               >
                 <div
+                  data-index={virtualRow.index}
                   ref={rowVirtualizer.measureElement}
                   className="flex items-center justify-center"
                 >

--- a/src/app/MainPage.tsx
+++ b/src/app/MainPage.tsx
@@ -6,49 +6,6 @@ import React, { useRef } from "react";
 import { useObserver } from "@/hooks/common/useObserver";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { postQueries } from "@/api/queries/postQueries";
-import { IPostSummaryData } from "@/api/types/post";
-
-const PostList = React.memo(function PostList({
-  posts,
-}: {
-  posts: IPostSummaryData[];
-}) {
-  return (
-    <>
-      {posts.map((post) => {
-        const userInfo: IUserItem = {
-          userId: post.userId,
-          nickname: post.nickname,
-          animalType: post.postType,
-          profileImageUrl: post.profileImageUrl ?? undefined,
-        };
-        const postContent: IPostContent = {
-          thumbnailUrl: post.thumbnailUrl,
-          content: post.transformedContent,
-        };
-        const postInfo: IPostFooter = {
-          postId: post.id,
-          didLike: post.liked,
-          likeCount: post.likeCount,
-          commentCount: post.commentCount,
-          timestamp: new Date(post.createdAt),
-          emotion: post.emotion,
-        };
-        return (
-          <PostCard key={`post-${post.id}`} postId={post.id}>
-            <PostCard.Header
-              userInfo={userInfo}
-              isMyPost={post.myPost}
-              postId={post.id}
-            />
-            <PostCard.Content {...postContent} />
-            <PostCard.Footer {...postInfo} />
-          </PostCard>
-        );
-      })}
-    </>
-  );
-});
 
 export default function MainPage() {
   const { data, fetchNextPage, hasNextPage, isLoading, error } =
@@ -82,10 +39,40 @@ export default function MainPage() {
   }
 
   return (
-    <div className="pt-2 pb-16 flex flex-col gap-2.5 px-2">
-      {data.pages.map((page, pageIndex) => (
-        <PostList key={`page-${pageIndex}`} posts={page.content} />
-      ))}
+    <div className="pt-2 flex flex-col gap-2.5 px-2">
+      {data.pages.map((page) =>
+        page.content.map((post) => {
+          const userInfo: IUserItem = {
+            userId: post.userId,
+            nickname: post.nickname,
+            animalType: post.postType,
+            profileImageUrl: post.profileImageUrl ?? undefined,
+          };
+          const postContent: IPostContent = {
+            thumbnailUrl: post.thumbnailUrl,
+            content: post.transformedContent,
+          };
+          const postInfo: IPostFooter = {
+            postId: post.id,
+            didLike: post.liked,
+            likeCount: post.likeCount,
+            commentCount: post.commentCount,
+            timestamp: new Date(post.createdAt),
+            emotion: post.emotion,
+          };
+          return (
+            <PostCard key={`post-${post.id}`} postId={post.id}>
+              <PostCard.Header
+                userInfo={userInfo}
+                isMyPost={post.myPost}
+                postId={post.id}
+              />
+              <PostCard.Content {...postContent} />
+              <PostCard.Footer {...postInfo} />
+            </PostCard>
+          );
+        }),
+      )}
       <div ref={lastElementRef} />
     </div>
   );

--- a/src/app/MainPage.tsx
+++ b/src/app/MainPage.tsx
@@ -11,7 +11,7 @@ import { useObserver } from "@/hooks/common/useObserver";
 export default function MainPage() {
   const parentRef = useRef(null);
 
-  const { data, fetchNextPage, hasNextPage, isLoading, error } =
+  const { data, fetchNextPage, hasNextPage, isPending, error } =
     useInfiniteQuery({
       ...postQueries.list(),
     });
@@ -20,7 +20,7 @@ export default function MainPage() {
   useObserver({
     target: lastElementRef as React.RefObject<HTMLElement>,
     onIntersect: ([entry]) => {
-      if (entry.isIntersecting && hasNextPage && !isLoading) {
+      if (entry.isIntersecting && hasNextPage && !isPending) {
         fetchNextPage();
       }
     },
@@ -40,7 +40,7 @@ export default function MainPage() {
   });
 
   // TODO: 로딩 스켈레톤 추가
-  if (isLoading) {
+  if (isPending) {
     return <div>Loading...</div>;
   }
 

--- a/src/app/MainPage.tsx
+++ b/src/app/MainPage.tsx
@@ -8,9 +8,11 @@ import { postQueries } from "@/api/queries/postQueries";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useObserver } from "@/hooks/common/useObserver";
 
-export default function MainPage() {
-  const parentRef = useRef(null);
+interface IMainPage {
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+}
 
+export default function MainPage({ scrollContainerRef }: IMainPage) {
   const { data, fetchNextPage, hasNextPage, isPending, error } =
     useInfiniteQuery({
       ...postQueries.list(),
@@ -30,7 +32,7 @@ export default function MainPage() {
 
   const rowVirtualizer = useVirtualizer({
     count: allPosts.length,
-    getScrollElement: () => parentRef.current,
+    getScrollElement: () => scrollContainerRef.current,
     estimateSize: () => 310, // PostCard 높이(300) + gap(10) = 310
     overscan: 5,
     getItemKey: (index) => {
@@ -55,30 +57,13 @@ export default function MainPage() {
   }
 
   return (
-    <div className="pt-2 px-2 h-screen overflow-auto" ref={parentRef}>
+    <div className="pt-2 px-2">
       <div
         className="w-full relative"
         style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
       >
         {rowVirtualizer.getVirtualItems().map((virtualRow) => {
           const post = allPosts[virtualRow.index];
-
-          if (!post) {
-            return (
-              <div
-                key={`loading-${virtualRow.index}`}
-                className="absolute top-0 left-0 w-full"
-                style={{
-                  height: `${virtualRow.size}px`,
-                  transform: `translateY(${virtualRow.start}px)`,
-                }}
-              >
-                <div className="flex items-center justify-center h-full">
-                  <div>Loading...</div>
-                </div>
-              </div>
-            );
-          }
 
           const userInfo: IUserItem = {
             userId: post.userId,

--- a/src/app/MainPage.tsx
+++ b/src/app/MainPage.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useEffect } from "react";
 import { PostCard } from "@/components/common";
 import { IPostContent } from "@/components/common/PostCard/PostContent";
 import { IUserItem } from "@/components/common/UserItem";
@@ -39,7 +39,37 @@ export default function MainPage({ scrollContainerRef }: IMainPage) {
       const post = allPosts[index];
       return post ? `post-${post.id}` : `loading-${index}`;
     },
+    onChange: (instance) => {
+      // 현재 스크롤 위치
+      const scrollOffset = instance.scrollOffset;
+      if (scrollOffset === null || scrollOffset === undefined) return;
+
+      // 현재 스크롤 위치에 가장 가까운 아이템 찾기
+      const virtualItems = instance.getVirtualItems();
+      if (virtualItems.length === 0) return;
+      const currentItem =
+        virtualItems.find(
+          (item) => scrollOffset >= item.start && scrollOffset <= item.end,
+        ) || virtualItems[0];
+
+      // 현재 아이템의 index를 session storage에 저장
+      if (currentItem && currentItem.index > 0) {
+        sessionStorage.setItem("scrollIndex", currentItem.index.toString());
+      }
+    },
   });
+
+  // 스크롤 위치 복원
+  useEffect(() => {
+    if (!data || allPosts.length === 0) {
+      return;
+    }
+
+    const savedIndex = sessionStorage.getItem("scrollIndex");
+    if (savedIndex) {
+      rowVirtualizer.scrollToIndex(Number(savedIndex), { align: "start" });
+    }
+  }, [data, allPosts.length, rowVirtualizer]);
 
   // TODO: 로딩 스켈레톤 추가
   if (isPending) {

--- a/src/app/MainPage.tsx
+++ b/src/app/MainPage.tsx
@@ -9,12 +9,15 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { useObserver } from "@/hooks/common/useObserver";
 import { useScrollMemory } from "@/hooks/common/useScrollMemory";
 import { IPostSummaryData } from "@/api/types/post";
+import useScrollMemoryStore from "@/store/useScrollMemoryStore";
 
 interface IMainPage {
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
 }
 
 export default function MainPage({ scrollContainerRef }: IMainPage) {
+  const { setScrollPosition } = useScrollMemoryStore();
+
   const { data, fetchNextPage, hasNextPage, isPending, error } =
     useInfiniteQuery({
       ...postQueries.list(),
@@ -102,7 +105,12 @@ export default function MainPage({ scrollContainerRef }: IMainPage) {
               style={{ transform: `translateY(${virtualRow.start}px)` }}
             >
               <div className="pb-2.5">
-                <PostCard postId={post.id}>
+                <PostCard
+                  postId={post.id}
+                  onClick={() => {
+                    setScrollPosition("main-page", virtualRow.index);
+                  }}
+                >
                   <PostCard.Header
                     userInfo={userInfo}
                     isMyPost={post.myPost}

--- a/src/app/member/[userId]/MemberPage.tsx
+++ b/src/app/member/[userId]/MemberPage.tsx
@@ -11,6 +11,7 @@ import { IPostContent } from "@/components/common/PostCard/PostContent";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useScrollMemory } from "@/hooks/common/useScrollMemory";
 import { IPostSummaryData } from "@/api/types/post";
+import useScrollMemoryStore from "@/store/useScrollMemoryStore";
 
 interface IMemberPage {
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
@@ -18,6 +19,7 @@ interface IMemberPage {
 
 export default function MemberPage({ scrollContainerRef }: IMemberPage) {
   const { userId } = useParams();
+  const { setScrollPosition } = useScrollMemoryStore();
 
   const {
     data: postList,
@@ -117,7 +119,16 @@ export default function MemberPage({ scrollContainerRef }: IMemberPage) {
               style={{ transform: `translateY(${virtualRow.start}px)` }}
             >
               <div className="px-2 pb-2.5">
-                <PostCard key={`post-${post.id}`} postId={post.id}>
+                <PostCard
+                  key={`post-${post.id}`}
+                  postId={post.id}
+                  onClick={() => {
+                    setScrollPosition(
+                      `member-page-${userId}`,
+                      virtualRow.index,
+                    );
+                  }}
+                >
                   <PostCard.Header
                     userInfo={userInfo}
                     isMyPost={post.myPost}

--- a/src/app/member/[userId]/MemberPage.tsx
+++ b/src/app/member/[userId]/MemberPage.tsx
@@ -109,6 +109,7 @@ export default function MemberPage({ scrollContainerRef }: IMemberPage) {
                 style={{ transform: `translateY(${virtualRow.start}px)` }}
               >
                 <div
+                  data-index={virtualRow.index}
                   ref={rowVirtualizer.measureElement}
                   className="flex items-center justify-center"
                 >

--- a/src/app/member/[userId]/MemberPage.tsx
+++ b/src/app/member/[userId]/MemberPage.tsx
@@ -9,6 +9,8 @@ import { IPostFooter } from "@/components/common/PostCard/PostFooter";
 import { IUserItem } from "@/components/common/UserItem";
 import { IPostContent } from "@/components/common/PostCard/PostContent";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { useScrollMemory } from "@/hooks/common/useScrollMemory";
+import { IPostSummaryData } from "@/api/types/post";
 
 interface IMemberPage {
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
@@ -21,6 +23,7 @@ export default function MemberPage({ scrollContainerRef }: IMemberPage) {
     data: postList,
     fetchNextPage,
     hasNextPage,
+    isPending,
   } = useInfiniteQuery({
     ...postQueries.userPostList({ userId: Number(userId) }),
   });
@@ -29,7 +32,7 @@ export default function MemberPage({ scrollContainerRef }: IMemberPage) {
   useObserver({
     target: lastElementRef as React.RefObject<HTMLElement>,
     onIntersect: ([entry]) => {
-      if (entry.isIntersecting && hasNextPage) {
+      if (entry.isIntersecting && hasNextPage && !isPending) {
         fetchNextPage();
       }
     },
@@ -40,69 +43,95 @@ export default function MemberPage({ scrollContainerRef }: IMemberPage) {
     : [];
 
   const rowVirtualizer = useVirtualizer({
-    count: allPosts.length,
+    count: allPosts.length + 1, // ProfileSummary + posts
     getScrollElement: () => scrollContainerRef.current,
-    estimateSize: () => 310,
+    estimateSize: (index) => {
+      if (index === 0) return 322; // ProfileSummary 높이
+      return 310; // PostCard 높이(300) + gap(10) = 310
+    },
     overscan: 5,
     getItemKey: (index) => {
-      const post = allPosts[index];
+      if (index === 0) return "profile-summary";
+      const post = allPosts[index - 1];
       return post ? `post-${post.id}` : `loading-${index}`;
     },
   });
 
+  useScrollMemory<IPostSummaryData>({
+    key: `member-page-${userId}`,
+    virtualizer: rowVirtualizer,
+    allItems: allPosts,
+    enabled: !isPending && !!postList,
+  });
+
   return (
     <div className="flex flex-col gap-4 items-center">
-      <ProfileSummary userId={Number(userId)} />
-      <div className="px-2 w-full">
-        <div
-          className="relative w-full"
-          style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
-        >
-          {rowVirtualizer.getVirtualItems().map((virtualRow) => {
-            const post = allPosts[virtualRow.index];
-            const userInfo: IUserItem = {
-              userId: post.userId,
-              nickname: post.nickname,
-              animalType: post.postType,
-              profileImageUrl: post.profileImageUrl ?? undefined,
-            };
-            const postContent: IPostContent = {
-              thumbnailUrl: post.thumbnailUrl,
-              content: post.transformedContent,
-            };
-            const postInfo: IPostFooter = {
-              postId: post.id,
-              didLike: post.liked,
-              likeCount: post.likeCount,
-              commentCount: post.commentCount,
-              timestamp: new Date(post.createdAt),
-              emotion: post.emotion,
-            };
+      <div
+        className="relative w-full"
+        style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+      >
+        {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+          if (virtualRow.index === 0) {
+            // ProfileSummary 렌더링
             return (
               <div
-                key={`post-${post.id}`}
+                key="profile-summary"
                 data-index={virtualRow.index}
                 ref={rowVirtualizer.measureElement}
-                className="absolute top-0 left-0 w-full"
+                className="absolute top-0 left-0 w-full pb-2"
                 style={{ transform: `translateY(${virtualRow.start}px)` }}
               >
-                <div className="pb-2.5">
-                  <PostCard key={`post-${post.id}`} postId={post.id}>
-                    <PostCard.Header
-                      userInfo={userInfo}
-                      isMyPost={post.myPost}
-                      postId={post.id}
-                    />
-                    <PostCard.Content {...postContent} />
-                    <PostCard.Footer {...postInfo} />
-                  </PostCard>
+                <div className="flex flex-col gap-4 items-center">
+                  <ProfileSummary userId={Number(userId)} />
                 </div>
               </div>
             );
-          })}
-        </div>
-        <div ref={lastElementRef} />
+          }
+
+          // Post 렌더링
+          const post = allPosts[virtualRow.index - 1];
+          const userInfo: IUserItem = {
+            userId: post.userId,
+            nickname: post.nickname,
+            animalType: post.postType,
+            profileImageUrl: post.profileImageUrl ?? undefined,
+          };
+          const postContent: IPostContent = {
+            thumbnailUrl: post.thumbnailUrl,
+            content: post.transformedContent,
+          };
+          const postInfo: IPostFooter = {
+            postId: post.id,
+            didLike: post.liked,
+            likeCount: post.likeCount,
+            commentCount: post.commentCount,
+            timestamp: new Date(post.createdAt),
+            emotion: post.emotion,
+          };
+          return (
+            <div
+              key={`post-${post.id}`}
+              data-index={virtualRow.index}
+              ref={rowVirtualizer.measureElement}
+              className="absolute top-0 left-0 w-full"
+              style={{ transform: `translateY(${virtualRow.start}px)` }}
+            >
+              <div className="px-2 pb-2.5">
+                <PostCard key={`post-${post.id}`} postId={post.id}>
+                  <PostCard.Header
+                    userInfo={userInfo}
+                    isMyPost={post.myPost}
+                    postId={post.id}
+                  />
+                  <PostCard.Content {...postContent} />
+                  <PostCard.Footer {...postInfo} />
+                </PostCard>
+              </div>
+            </div>
+          );
+        })}
       </div>
+      <div ref={lastElementRef} />
     </div>
   );
 }

--- a/src/components/common/NavigationBar.tsx
+++ b/src/components/common/NavigationBar.tsx
@@ -12,24 +12,50 @@ import {
   PlusIcon,
 } from "lucide-react";
 
-function renderIconButton(route: string, icon: React.ReactNode) {
+function renderIconButton(
+  route: string,
+  icon: React.ReactNode,
+  onClick?: () => void,
+) {
   return (
-    <Link to={route}>
+    <Link to={route} onClick={onClick}>
       <Button variant="ghost">{icon}</Button>
     </Link>
   );
 }
 
-export default function NavigationBar() {
+export default function NavigationBar({
+  scrollContainerRef,
+}: {
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+}) {
   const location = useLocation();
   const { token } = useTokenStore();
   const { data: profileImage } = useQuery({
     ...userQueries.userProfileImage(),
   });
 
+  const handleScrollToTop = ({ pathname }: { pathname: string }) => {
+    // 현재 홈 페이지에 있는 경우에만 스크롤을 맨 위로 올림
+    if (location.pathname === pathname) {
+      // 직접 스크롤 컨테이너에 접근하여 스크롤을 맨 위로 올림
+      const scrollContainer = scrollContainerRef.current;
+      if (scrollContainer) {
+        scrollContainer.scrollTo({
+          top: 0,
+          behavior: "smooth",
+        });
+      }
+    }
+  };
+
   return (
     <div className="flex justify-between items-center border-t border-border/30 px-5 py-1 fixed bottom-0 w-full bg-background max-w-[430px] mx-auto">
-      {renderIconButton("/", <HomeIcon className="stroke-foreground size-6" />)}
+      {renderIconButton(
+        "/",
+        <HomeIcon className="stroke-foreground size-6" />,
+        () => handleScrollToTop({ pathname: "/" }),
+      )}
       {renderIconButton(
         "/event",
         <PartyPopper className="stroke-foreground size-6" />,

--- a/src/components/common/PostCard/PostCard.tsx
+++ b/src/components/common/PostCard/PostCard.tsx
@@ -7,15 +7,17 @@ import { useNavigate } from "react-router-dom";
 interface IPostCard {
   children: ReactNode;
   postId: number;
+  onClick?: () => void;
 }
 
-function PostCard({ children, postId }: IPostCard) {
+function PostCard({ children, postId, onClick }: IPostCard) {
   const navigate = useNavigate();
 
   return (
     <div
       className="flex flex-col gap-2 rounded-2xl bg-background border border-foreground/30 pl-2.5 pr-2 pt-1 pb-1 shadow-sm"
       onClick={() => {
+        onClick?.();
         navigate(`/detail/${postId}`);
       }}
     >

--- a/src/hooks/common/useScrollMemory.ts
+++ b/src/hooks/common/useScrollMemory.ts
@@ -58,7 +58,22 @@ export const useScrollMemory = <T>({
 
     const savedIndex = getScrollPosition(key);
     if (savedIndex !== null) {
-      virtualizer.scrollToIndex(savedIndex, { align: "start" });
+      // 가상화 초기화를 기다린 후 스크롤
+      const timeoutId = setTimeout(() => {
+        // 저장된 인덱스가 유효한지 확인
+        const maxIndex = virtualizer.options.count;
+        const validIndex = Math.min(savedIndex, maxIndex);
+
+        // 인덱스가 유효한 경우에만 스크롤
+        if (validIndex >= 0) {
+          virtualizer.scrollToIndex(validIndex, {
+            align: "start",
+            behavior: "auto",
+          });
+        }
+      }, 100); // 100ms 지연
+
+      return () => clearTimeout(timeoutId);
     }
   }, [key, allItems.length, virtualizer, enabled, getScrollPosition]);
 };

--- a/src/hooks/common/useScrollMemory.ts
+++ b/src/hooks/common/useScrollMemory.ts
@@ -43,7 +43,7 @@ export const useScrollMemory = <T>({
       }
     };
 
-    scrollElement.addEventListener("scroll", handleScroll, { passive: true });
+    scrollElement.addEventListener("scroll", handleScroll);
 
     return () => {
       scrollElement.removeEventListener("scroll", handleScroll);

--- a/src/hooks/common/useScrollMemory.ts
+++ b/src/hooks/common/useScrollMemory.ts
@@ -1,0 +1,79 @@
+import { VirtualItem, Virtualizer } from "@tanstack/react-virtual";
+import { useEffect } from "react";
+
+interface UseScrollMemoryOptions<T> {
+  key: string;
+  virtualizer: Virtualizer<HTMLDivElement, Element>;
+  allItems: T[];
+  enabled?: boolean;
+}
+
+export const useScrollMemory = <T>({
+  key,
+  virtualizer,
+  allItems,
+  enabled = true,
+}: UseScrollMemoryOptions<T>) => {
+  useEffect(() => {
+    if (!enabled || !virtualizer) return;
+
+    const scrollElement = virtualizer.options.getScrollElement();
+    if (!scrollElement) return;
+
+    const handleScroll = () => {
+      // 스크롤 위치 찾기
+      const scrollOffset = virtualizer.scrollOffset;
+      if (scrollOffset === null || scrollOffset === undefined) return;
+
+      // 현재 스크롤 위치에 가장 가까운 아이템 찾기
+      const virtualItems = virtualizer.getVirtualItems();
+      if (virtualItems.length === 0) return;
+      const currentItem =
+        virtualItems.find(
+          (item: VirtualItem) =>
+            scrollOffset >= item.start && scrollOffset <= item.end,
+        ) || virtualItems[0];
+
+      // 현재 아이템의 index를 session storage에 저장
+      if (currentItem && currentItem.index > 0) {
+        sessionStorage.setItem(
+          `${key}-scrollIndex`,
+          currentItem.index.toString(),
+        );
+      }
+    };
+
+    scrollElement.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      scrollElement.removeEventListener("scroll", handleScroll);
+    };
+  }, [key, virtualizer, enabled]);
+
+  // 스크롤 위치 복원
+  useEffect(() => {
+    if (!enabled || allItems.length === 0) {
+      return;
+    }
+
+    const savedIndex = sessionStorage.getItem(`${key}-scrollIndex`);
+    if (savedIndex) {
+      virtualizer.scrollToIndex(Number(savedIndex), { align: "start" });
+    }
+  }, [key, allItems.length, virtualizer, enabled]);
+
+  // 새로고침 시 session storage 초기화
+  useEffect(() => {
+    if (!enabled) return;
+
+    const cleanup = () => {
+      sessionStorage.removeItem(`${key}-scrollIndex`);
+    };
+
+    window.addEventListener("pagehide", cleanup);
+
+    return () => {
+      window.removeEventListener("pagehide", cleanup);
+    };
+  }, [key, enabled]);
+};

--- a/src/store/useScrollMemoryStore.ts
+++ b/src/store/useScrollMemoryStore.ts
@@ -1,0 +1,37 @@
+import { create } from "zustand";
+
+interface IScrollMemoryStore {
+  scrollPositions: Map<string, number>;
+  setScrollPosition: (key: string, index: number) => void;
+  getScrollPosition: (key: string) => number | null;
+  clearScrollPosition: (key: string) => void;
+  clearAllScrollPositions: () => void;
+}
+
+const useScrollMemoryStore = create<IScrollMemoryStore>((set, get) => ({
+  scrollPositions: new Map(),
+
+  setScrollPosition: (key: string, index: number) => {
+    set((state) => {
+      const newScrollPositions = new Map(state.scrollPositions);
+      newScrollPositions.set(key, index);
+      return { scrollPositions: newScrollPositions };
+    });
+  },
+
+  getScrollPosition: (key: string) => get().scrollPositions.get(key) ?? null,
+
+  clearScrollPosition: (key: string) => {
+    set((state) => {
+      const newScrollPositions = new Map(state.scrollPositions);
+      newScrollPositions.delete(key);
+      return { scrollPositions: newScrollPositions };
+    });
+  },
+
+  clearAllScrollPositions: () => {
+    set({ scrollPositions: new Map() });
+  },
+}));
+
+export default useScrollMemoryStore;


### PR DESCRIPTION
## 🚀 작업 내용
- 무한 스크롤 최적화
## ✨ 작업 상세 설명
- 가상 스크롤(@tanstack/react-virtual) 활용하여 무한 스크롤되어도 **화면에 표시되는 부분만 렌더링 되도록**
- 스크롤 위치 기억하여 해당 페이지로 돌아왔을 때 자동으로 그 스크롤 위치로 이동되도록
  - 특히 게시글을 눌러 게시글 상세 페이지로 이동하는 경우, 해당 게시글이 제일 위쪽으로 가도록 구현
- `MainPage`, `MemberPage`에 적용
  - `MainPage`의 경우 스크롤 아래쪽에 있을 때, NavBar의 홈 버튼 누르면 최 상단으로 스크롤 올라가도록 함
## 📌 관련 이슈
- #223 

### 🔥 문제 상황 (선택)
- 무한 스크롤로 데이터 쌓이면 HTML 요소가 무한히 쌓임
![image](https://github.com/user-attachments/assets/f035d2b4-8ca6-4b69-8574-4a3ecb39f656)
- 이로 인해 렌더링 시간 오래 걸림

### 💦 해결 방법 (선택)
- 가상 스크롤 기법 활용하여, 화면에 표시되는 요소들만 렌더링
![무한 스크롤 요소 엄청 많음 - after](https://github.com/user-attachments/assets/c397cd38-a821-4be7-adbc-0610138fb432)



#### 마지막 데이터 렌더링 시간 (데이터 총 820개) - 422ms -> 24.5ms
| before | after |
|:--:| :--: |
| ![image](https://github.com/user-attachments/assets/30898c1a-bb3c-49c4-a4ab-b78f831b90b3) | ![image](https://github.com/user-attachments/assets/6c8c6fb7-de43-4f89-a4d7-e073f26ee1f4) | 

#### 데이터 전체 로드 후, 페이지 이동하고 돌아올 때 렌더링 시간 - 736ms -> 44.7ms
| before | after |
|:--:| :--: |
| ![image](https://github.com/user-attachments/assets/9e69297e-35ae-4e98-b0e2-4d940136a28a) | ![image](https://github.com/user-attachments/assets/35717b35-20c1-4da8-83d1-9afd51265470) | 

## 💬 추후 수정해야 하는 부분 및 기타 논의 사항 (선택)

## 📄 REFERENCE (선택)
> [노션 정리](https://www.notion.so/jessiesaying/21e2494b69ef8043be2dca42a8001abb?source=copy_link)
## 📢 리뷰 요구 사항 (선택)
