### PR TITLE
fix: 최근 메시지 사라지는 오류 수정

### DIFF
--- a/src/components/pages/Chat/ChatContainer.tsx
+++ b/src/components/pages/Chat/ChatContainer.tsx
@@ -15,6 +15,9 @@ interface IChatContainer {
 }
 
 export default function ChatContainer({ chatroomId }: IChatContainer) {
+  const [websocketMessages, setWebsocketMessages] = useState<
+    IReceivedChatMessage[]
+  >([]);
   const [messages, setMessages] = useState<IReceivedChatMessage[]>([]);
   const [selectedAnimal, setSelectedAnimal] = useState<ApiAnimalType>(
     ApiAnimalType.CAT,
@@ -52,7 +55,7 @@ export default function ChatContainer({ chatroomId }: IChatContainer) {
 
   // 메시지 수신 콜백을 useCallback으로 메모이제이션
   const handleMessageReceived = useCallback((message: IReceivedChatMessage) => {
-    setMessages((prevMessages) => [message, ...prevMessages]);
+    setWebsocketMessages((prevMessages) => [message, ...prevMessages]);
   }, []);
 
   // WebSocket 연결
@@ -137,8 +140,20 @@ export default function ChatContainer({ chatroomId }: IChatContainer) {
   return (
     <div className="w-full h-full bg-foreground/10 rounded-xl gap-3 p-3 flex flex-col pb-26">
       <div ref={scrollContainerRef} className="flex-1 overflow-y-auto pb-2">
-        <div className="w-full flex flex-col-reverse items-center justify-end">
+        <div className="w-full flex flex-col-reverse items-center justify-end gap-1">
           {/* TODO: 메시지 불러오는 로직 추가 */}
+          {websocketMessages.map((message, index) => (
+            <ChatMessage
+              key={`${message.senderId}-${index}`}
+              userId={message.senderId}
+              profileImageUrl={message.senderProfileImage}
+              nickname={message.senderNickname}
+              align={message.senderId === userIdData?.userId ? "right" : "left"}
+              message={message.message}
+              animalType={message.animalType}
+              createdAt={message.timestamp}
+            />
+          ))}
           {messages.map((message, index) => (
             <ChatMessage
               key={`${message.senderId}-${index}`}


### PR DESCRIPTION
## 🚀 작업 내용
- 위로 스크롤시 다시 내려오면 최근 메시지가 사라져있는 오류 수정
![최근 메시지 안보임](https://github.com/user-attachments/assets/f6f4e3d9-52cb-413b-bb0e-6cb124a5cefb)

## ✨ 작업 상세 설명
- websocket으로 오는 메시지가 무한스크롤로 새로 데이터 불러올 때 덮어씌워져버리는 오류 발견
- websocket으로 오는 메시지와 무한스크롤로 보이는 API 메시지를 분리하여 렌더링해줌
## 📌 관련 이슈
- #245 

### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 💬 추후 수정해야 하는 부분 및 기타 논의 사항 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
