### PR TITLE
fix: cicd dev/prod의 경로 분리

### DIFF
--- a/.github/workflows/dev-CICD.yml
+++ b/.github/workflows/dev-CICD.yml
@@ -90,7 +90,7 @@ jobs:
           context:
           build-args: |
             VITE_API_URL=${{ secrets.VITE_API_URL }}
-            VITE_AI_API_URL=${{ secrets.VITE_AI_API_URL }}
+            VITE_AI_API_URL=${{ secrets.VITE_AI_API_URL_DEV }}
             VITE_CLOUDFRONT_URL=${{ secrets.VITE_CLOUDFRONT_URL }}
           push: true
           tags: |

--- a/.github/workflows/prod-CICD.yml
+++ b/.github/workflows/prod-CICD.yml
@@ -167,7 +167,7 @@ jobs:
           context: .
           build-args: |
             VITE_API_URL=${{ secrets.VITE_API_URL }}
-            VITE_AI_API_URL=${{ secrets.VITE_AI_API_URL }}
+            VITE_AI_API_URL=${{ secrets.VITE_AI_API_URL_PROD }}
             VITE_CLOUDFRONT_URL=${{ secrets.VITE_CLOUDFRONT_URL }}
           push: true
           tags: |


### PR DESCRIPTION
## 🚀 작업 내용
- cicd 코드에서 dev/prod의 경로를 다르게 함
## ✨ 작업 상세 설명
- 프로필 추천을 위해 연결해 둔 AI 경로가 dev와 prod 환경에서 달라야 함
## 📌 관련 이슈
- 없음

### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 💬 추후 수정해야 하는 부분 및 기타 논의 사항 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
