### PR TITLE
fix: 게시글 상세페이지에서 삭제시 자동으로 페이지 이동 안되는 오류 수정

### DIFF
--- a/src/api/queries/postQueries.ts
+++ b/src/api/queries/postQueries.ts
@@ -89,9 +89,11 @@ export const postQueries = {
   delete: ({
     postId,
     queryClient,
+    navigateTo,
   }: {
     postId: number;
     queryClient: QueryClient;
+    navigateTo?: () => void;
   }) => ({
     mutationKey: [...postQueries.all(), "delete", postId],
     mutationFn: () => deletePost(postId),
@@ -102,6 +104,7 @@ export const postQueries = {
       queryClient.invalidateQueries({
         queryKey: [...postQueries.all(), "userPostList"],
       });
+      navigateTo?.();
     },
     onError: createDefaultErrorHandler(ALERT_MESSAGES.POST_DELETE_FAILED),
   }),

--- a/src/app/detail/[postId]/DetailPostPage.tsx
+++ b/src/app/detail/[postId]/DetailPostPage.tsx
@@ -56,6 +56,7 @@ function DetailPostPage() {
                 }}
                 isMyPost={data.myPost}
                 postId={Number(postId)}
+                isDetailPage={true}
               />
               {data.imageUrls.length > 0 && (
                 <ImageCarousel images={data.imageUrls} />

--- a/src/components/common/PostCard/ContextMenu.tsx
+++ b/src/components/common/PostCard/ContextMenu.tsx
@@ -6,14 +6,28 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { postQueries } from "@/api/queries/postQueries";
 import DotsVerticalIcon from "@/assets/icon/dots-vertical.svg?react";
 
-export default function ContextMenu({ postId }: { postId: number }) {
+export default function ContextMenu({
+  postId,
+  isDetailPage,
+}: {
+  postId: number;
+  isDetailPage: boolean;
+}) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
   const buttonRef = useRef<HTMLButtonElement>(null);
   const { mutate: deletePost } = useMutation({
-    ...postQueries.delete({ postId, queryClient }),
+    ...postQueries.delete({
+      postId,
+      queryClient,
+      navigateTo: () => {
+        if (isDetailPage) {
+          navigate(-1);
+        }
+      },
+    }),
   });
 
   const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/src/components/common/PostCard/PostHeader.tsx
+++ b/src/components/common/PostCard/PostHeader.tsx
@@ -5,17 +5,19 @@ interface IPostHeader {
   userInfo: IUserItem;
   isMyPost: boolean;
   postId: number;
+  isDetailPage?: boolean;
 }
 
 export default function PostHeader({
   userInfo,
   isMyPost,
   postId,
+  isDetailPage = false,
 }: IPostHeader) {
   return (
     <div className="flex flex-row items-center justify-between w-full">
       <UserItem {...userInfo} />
-      {isMyPost && <ContextMenu postId={postId} />}
+      {isMyPost && <ContextMenu postId={postId} isDetailPage={isDetailPage} />}
     </div>
   );
 }


### PR DESCRIPTION
## 🚀 작업 내용
- 게시글 상세 페이지에서 삭제시 이전 페이지로 이동되도록 함
## ✨ 작업 상세 설명
- 게시글 상세 페이지에서 게시글을 삭제하는 경우, 어디로든 이동되지 않아서 불편함
- 따라서 상세페이지의 경우에는 게시글 삭제하면 이전 페이지로 이동 할 수 있도록 로직 추가함
## 📌 관련 이슈
- 이슈 번호

### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 💬 추후 수정해야 하는 부분 및 기타 논의 사항 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
